### PR TITLE
Support explicit bindings in module functions

### DIFF
--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/fir/KoinModuleFirGenerator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/fir/KoinModuleFirGenerator.kt
@@ -90,6 +90,7 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
         private val CONFIGURATION_ANNOTATION = KoinAnnotationFqNames.CONFIGURATION
 
         // Definition annotations
+        private val ALL_DEFINITION_ANNOTATIONS = KoinAnnotationFqNames.KOIN_DEFINITION_ANNOTATIONS.toSet()
         private val SINGLETON_ANNOTATION = KoinAnnotationFqNames.SINGLETON
         private val SINGLE_ANNOTATION = KoinAnnotationFqNames.SINGLE
         private val FACTORY_ANNOTATION = KoinAnnotationFqNames.FACTORY
@@ -470,6 +471,41 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
 
     private fun extractScopeClassId(classSymbol: FirClassSymbol<*>): ClassId? =
         extractScopeClassIdFromAnnotations(classSymbol.fir.annotations.filterIsInstance<FirAnnotationCall>())
+
+    /**
+     * Extract explicit binding ClassIds from @Single(binds = [...]) and related definition annotations.
+     * Null means the binds parameter was omitted, while an empty list means it was explicitly present
+     * but empty/defaulted, so auto-binding should be suppressed.
+     */
+    private fun extractExplicitBindingClassIdsFromAnnotations(annotations: List<FirAnnotationCall>): List<ClassId>? {
+        val annotation = annotations.firstOrNull { annotation ->
+            val annotationClassId = annotation.annotationTypeRef.coneTypeOrNull?.classId
+            annotationClassId?.asSingleFqName() in ALL_DEFINITION_ANNOTATIONS
+        } ?: return null
+
+        val bindings = mutableListOf<ClassId>()
+        var foundBindsArgument = false
+
+        for (argument in annotation.argumentList.arguments) {
+            if (argument is FirVarargArgumentsExpression) {
+                foundBindsArgument = true
+                for (element in argument.arguments) {
+                    val classId = extractClassIdFromExpression(element)
+                    if (classId != null && classId.asSingleFqName().asString() != "kotlin.Unit") {
+                        bindings.add(classId)
+                    }
+                }
+            }
+        }
+
+        return if (foundBindsArgument) bindings else null
+    }
+
+    private fun extractExplicitBindingClassIds(functionSymbol: FirNamedFunctionSymbol): List<ClassId>? =
+        extractExplicitBindingClassIdsFromAnnotations(functionSymbol.fir.annotations.filterIsInstance<FirAnnotationCall>())
+
+    private fun extractExplicitBindingClassIds(classSymbol: FirClassSymbol<*>): List<ClassId>? =
+        extractExplicitBindingClassIdsFromAnnotations(classSymbol.fir.annotations.filterIsInstance<FirAnnotationCall>())
 
     /**
      * Detect auto-binding ClassIds from the return type's supertypes.
@@ -933,7 +969,8 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
                             val qualifierName = extractQualifierName(classSymbol)
                             val qualifierTypeClassId = extractQualifierTypeClassId(classSymbol)
                             val scopeClassId = extractScopeClassId(classSymbol)
-                            val bindingClassIds = detectBindingClassIds(classSymbol.classId)
+                            val bindingClassIds = extractExplicitBindingClassIds(classSymbol)
+                                ?: detectBindingClassIds(classSymbol.classId)
 
                             log { "  Found @$defType class: ${classSymbol.classId} (orphan, needs hint)" }
                             if (qualifierName != null) log { "    qualifier: @Named(\"$qualifierName\")" }
@@ -1023,7 +1060,8 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
                         val qualifierName = extractQualifierName(functionSymbol)
                         val qualifierTypeClassId = extractQualifierTypeClassId(functionSymbol)
                         val scopeClassId = extractScopeClassId(functionSymbol)
-                        val bindingClassIds = detectBindingClassIds(returnTypeClassId)
+                        val bindingClassIds = extractExplicitBindingClassIds(functionSymbol)
+                            ?: detectBindingClassIds(returnTypeClassId)
 
                         log { "  Found @$defType function: ${callableId.callableName}() -> $returnTypeClassId (orphan, needs hint)" }
                         if (qualifierName != null) log { "    qualifier: @Named(\"$qualifierName\")" }
@@ -1102,7 +1140,8 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
                         val qualifierName = extractQualifierName(functionSymbol)
                         val qualifierTypeClassId = extractQualifierTypeClassId(functionSymbol)
                         val scopeClassId = extractScopeClassId(functionSymbol)
-                        val bindingClassIds = detectBindingClassIds(returnTypeClassId)
+                        val bindingClassIds = extractExplicitBindingClassIds(functionSymbol)
+                            ?: detectBindingClassIds(returnTypeClassId)
 
                         log { "  Found @$defType module function: ${containingClassId.shortClassName}.$funcName() -> $returnTypeClassId" }
                         if (qualifierName != null) log { "    qualifier: @Named(\"$qualifierName\")" }

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/AnnotationModels.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/AnnotationModels.kt
@@ -43,6 +43,7 @@ data class DefinitionFunction(
     val irFunction: IrSimpleFunction,
     val definitionType: DefinitionType,
     val returnTypeClass: IrClass,
+    val bindings: List<IrClass> = emptyList(),
     val scopeClass: IrClass? = null,
     val scopeArchetype: ScopeArchetype? = null,
     val createdAtStart: Boolean = false

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DefinitionCallBuilder.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DefinitionCallBuilder.kt
@@ -183,7 +183,7 @@ class DefinitionCallBuilder(
 
         val qualifier = qualifierExtractor.extractFromDeclaration(targetFunction)
 
-        return builder.irCall(koinFunction.symbol).apply {
+        val definitionCall = builder.irCall(koinFunction.symbol).apply {
             extensionReceiver = builder.irGet(moduleReceiver)
             putTypeArgument(0, returnTypeClass.defaultType)
 
@@ -204,6 +204,12 @@ class DefinitionCallBuilder(
                 targetFunction, returnTypeClass, moduleClass, builder, parentFunction, getterFunction
             )
             putValueArgument(2, definitionLambda)
+        }
+
+        return if (definition.bindings.isNotEmpty()) {
+            addBindings(definitionCall, definition.bindings, builder)
+        } else {
+            definitionCall
         }
     }
 

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinAnnotationProcessor.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinAnnotationProcessor.kt
@@ -554,10 +554,11 @@ class KoinAnnotationProcessor(
                 val defType = getDefinitionType(function) ?: return@mapNotNull null
                 val returnType = function.returnType
                 val returnTypeClass = (returnType.classifierOrNull?.owner as? IrClass) ?: return@mapNotNull null
+                val bindings = getExplicitBindings(function) ?: emptyList()
                 val scopeClass = getScopeClass(function)
                 val scopeArchetype = getScopeArchetype(function)
                 val createdAtStart = getCreatedAtStart(function)
-                DefinitionFunction(function, defType, returnTypeClass, scopeClass, scopeArchetype, createdAtStart)
+                DefinitionFunction(function, defType, returnTypeClass, bindings, scopeClass, scopeArchetype, createdAtStart)
             }
     }
 
@@ -1322,7 +1323,7 @@ class KoinAnnotationProcessor(
                 moduleClass.irClass,
                 defFunc.definitionType,
                 defFunc.returnTypeClass,
-                emptyList(), // bindings — function definitions don't yet support explicit binds
+                defFunc.bindings,
                 defFunc.scopeClass, // Scope class from @Scope annotation
                 defFunc.scopeArchetype, // Scope archetype from @ViewModelScope, @ActivityScope, etc.
                 defFunc.createdAtStart
@@ -1654,12 +1655,14 @@ class KoinAnnotationProcessor(
         val moduleFunctions = collectDefinitionFunctions(moduleIrClass)
         KoinPluginLogger.debug { "      Module functions: ${moduleFunctions.size} (${moduleFunctions.joinToString { it.irFunction.name.asString() }})" }
         for (defFunc in moduleFunctions) {
+            val hintBindings = discoverModuleFunctionBindingsFromHint(moduleIrClass, defFunc)
+            val bindings = if (hintBindings.isNotEmpty()) hintBindings else defFunc.bindings
             definitions.add(Definition.FunctionDef(
                 defFunc.irFunction,
                 moduleIrClass,
                 defFunc.definitionType,
                 defFunc.returnTypeClass,
-                emptyList(), // bindings — function definitions don't yet support explicit binds
+                bindings,
                 defFunc.scopeClass,
                 defFunc.scopeArchetype,
                 defFunc.createdAtStart
@@ -1737,6 +1740,41 @@ class KoinAnnotationProcessor(
             KoinPluginLogger.debug { "    -> WARNING: $moduleFqName has @ComponentScan but no scan hints found (hint functions unavailable)" }
         }
         return DependencyModuleResult(definitions, isComplete = isComplete)
+    }
+
+    private fun discoverModuleFunctionBindingsFromHint(
+        moduleIrClass: IrClass,
+        defFunc: DefinitionFunction
+    ): List<IrClass> {
+        val moduleClassId = moduleIrClass.classId ?: return emptyList()
+        val moduleId = KoinModuleFirGenerator.sanitizeModuleIdForHint(moduleClassId)
+        val hintName = KoinModuleFirGenerator.moduleDefinitionHintFunctionName(
+            moduleId,
+            defFunc.irFunction.name.asString()
+        )
+        val hintFunctions = cachedReferenceFunctions(
+            CallableId(KoinModuleFirGenerator.HINTS_PACKAGE, hintName)
+        )
+        val returnTypeFqName = defFunc.returnTypeClass.fqNameWhenAvailable
+
+        for (hintFuncSymbol in hintFunctions) {
+            val hintFunc = hintFuncSymbol.owner
+            val contributedType = hintFunc.valueParameters.firstOrNull()?.type
+            val contributedClass = (contributedType?.classifierOrNull as? IrClassSymbol)?.owner
+            if (returnTypeFqName != null && contributedClass?.fqNameWhenAvailable != returnTypeFqName) continue
+
+            val bindings = hintFunc.valueParameters
+                .filter { it.name.asString().startsWith("binding") }
+                .mapNotNull { (it.type.classifierOrNull as? IrClassSymbol)?.owner }
+            if (bindings.isNotEmpty()) {
+                KoinPluginLogger.debug {
+                    "      Module function hint bindings for ${moduleIrClass.name}.${defFunc.irFunction.name}(): ${bindings.map { it.fqNameWhenAvailable }}"
+                }
+                return bindings
+            }
+        }
+
+        return emptyList()
     }
 
     /**

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -63,6 +63,12 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     public void testDelegation_no_autobind() {
       runTest("koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.kt");
     }
+
+    @Test
+    @TestMetadata("provider_function_binds.kt")
+    public void testProvider_function_binds() {
+      runTest("koin-compiler-plugin/testData/box/bindings/provider_function_binds.kt");
+    }
   }
 
   @Nested

--- a/koin-compiler-plugin/testData/box/bindings/provider_function_binds.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/bindings/provider_function_binds.fir.ir.txt
@@ -1,0 +1,141 @@
+FILE fqName:<root> fileName:/test.kt
+  CLASS CLASS name:RepositoryImpl modality:FINAL visibility:public superTypes:[<root>.Repository]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.RepositoryImpl
+    CONSTRUCTOR visibility:public returnType:<root>.RepositoryImpl [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:RepositoryImpl modality:FINAL visibility:public superTypes:[<root>.Repository]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Repository
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.Repository
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.Repository
+  CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestModule
+    CONSTRUCTOR visibility:public returnType:<root>.TestModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:provideRepository visibility:public modality:FINAL returnType:<root>.RepositoryImpl
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestModule
+      annotations:
+        Single(binds = [CLASS_REFERENCE 'CLASS INTERFACE name:Repository modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Repository>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun provideRepository (): <root>.RepositoryImpl declared in <root>.TestModule'
+          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.RepositoryImpl' type=<root>.RepositoryImpl origin=null
+  CLASS INTERFACE name:Repository modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Repository
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: CALL 'public final fun module (<this>: <root>.TestModule): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=null
+                        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TestModule' type=<root>.TestModule origin=null
+      VAR name:impl type:<root>.RepositoryImpl [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.RepositoryImpl origin=null
+          TYPE_ARG T: <root>.RepositoryImpl
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      VAR name:repo type:<root>.Repository [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.Repository origin=null
+          TYPE_ARG T: <root>.Repository
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      VAR name:sameInstance type:kotlin.Boolean [val]
+        CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+          ARG arg0: GET_VAR 'val impl: <root>.RepositoryImpl declared in <root>.box' type=<root>.RepositoryImpl origin=null
+          ARG arg1: GET_VAR 'val repo: <root>.Repository declared in <root>.box' type=<root>.Repository origin=null
+      VAR name:correctType type:kotlin.Boolean [val]
+        TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=<root>.RepositoryImpl
+          GET_VAR 'val repo: <root>.Repository declared in <root>.box' type=<root>.Repository origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: WHEN type=kotlin.Boolean origin=ANDAND
+              BRANCH
+                if: GET_VAR 'val sameInstance: kotlin.Boolean declared in <root>.box' type=kotlin.Boolean origin=null
+                then: GET_VAR 'val correctType: kotlin.Boolean declared in <root>.box' type=kotlin.Boolean origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CONST Boolean type=kotlin.Boolean value=false
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CONST String type=kotlin.String value="FAIL: provider function binding not working"
+FILE fqName:<root> fileName:/testModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.TestModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: <root>.TestModule): org.koin.core.module.Module declared in <root>'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                CALL 'public final fun bind <S> (<this>: org.koin.core.definition.KoinDefinition<*>, clazz: kotlin.reflect.KClass<S of org.koin.plugin.module.dsl.bind>): org.koin.core.definition.KoinDefinition<*> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<*> origin=null
+                  TYPE_ARG S: <root>.Repository
+                  ARG <this>: CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                    TYPE_ARG T: <root>.RepositoryImpl
+                    ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                    ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:RepositoryImpl modality:FINAL visibility:public superTypes:[<root>.Repository]' type=kotlin.reflect.KClass<<root>.RepositoryImpl>
+                    ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                    ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.RepositoryImpl> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.RepositoryImpl
+                        VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                        VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                        BLOCK_BODY
+                          RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.RepositoryImpl declared in <root>.module.<anonymous>'
+                            CALL 'public final fun provideRepository (): <root>.RepositoryImpl declared in <root>.TestModule' type=<root>.RepositoryImpl origin=null
+                              ARG <this>: GET_VAR '<this>: <root>.TestModule declared in <root>.module' type=<root>.TestModule origin=null
+                  ARG clazz: CLASS_REFERENCE 'CLASS INTERFACE name:Repository modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Repository>
+FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/testModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_testModule__provideRepository visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.RepositoryImpl
+    VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:binding0 index:1 type:<root>.Repository
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+      CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+        ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/bindings/provider_function_binds.fir.txt
+++ b/koin-compiler-plugin/testData/box/bindings/provider_function_binds.fir.txt
@@ -1,0 +1,44 @@
+FILE: test.kt
+    @R|org/koin/core/annotation/Module|() public final class TestModule : R|kotlin/Any| {
+        public constructor(): R|TestModule| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|org/koin/core/annotation/Single|(binds = <collectionLiteralCall>(<getClass>(Q|Repository|))) public final fun provideRepository(): R|RepositoryImpl| {
+            ^provideRepository R|/RepositoryImpl.RepositoryImpl|()
+        }
+
+    }
+    public abstract interface Repository : R|kotlin/Any| {
+    }
+    public final class RepositoryImpl : R|Repository| {
+        public constructor(): R|RepositoryImpl| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/TestModule.TestModule|().R|/module|())
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval impl: R|RepositoryImpl| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|RepositoryImpl|>()
+        lval repo: R|Repository| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|Repository|>()
+        lval sameInstance: R|kotlin/Boolean| = ===(R|<local>/impl|, R|<local>/repo|)
+        lval correctType: R|kotlin/Boolean| = (R|<local>/repo| is R|RepositoryImpl|)
+        ^box when () {
+            R|<local>/sameInstance| && R|<local>/correctType| ->  {
+                String(OK)
+            }
+            else ->  {
+                String(FAIL: provider function binding not working)
+            }
+        }
+
+    }
+FILE: /testModuleModule.kt
+    public final fun R|TestModule|.module(): R|org/koin/core/module/Module|
+FILE: org/koin/plugin/hints/testModuleModule.kt
+    package org.koin.plugin.hints
+
+    @R|kotlin/Deprecated|(message = String(Koin compiler plugin internal hint function), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun moduledef_testModule__provideRepository(contributed: R|RepositoryImpl|, binding0: R|Repository|): R|kotlin/Unit|

--- a/koin-compiler-plugin/testData/box/bindings/provider_function_binds.kt
+++ b/koin-compiler-plugin/testData/box/bindings/provider_function_binds.kt
@@ -1,0 +1,28 @@
+// FILE: test.kt
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+import org.koin.dsl.koinApplication
+
+@Module
+class TestModule {
+    @Single(binds = [Repository::class])
+    fun provideRepository(): RepositoryImpl = RepositoryImpl()
+}
+
+interface Repository
+
+class RepositoryImpl : Repository
+
+fun box(): String {
+    val koin = koinApplication {
+        modules(TestModule().module())
+    }.koin
+
+    val impl = koin.get<RepositoryImpl>()
+    val repo = koin.get<Repository>()
+
+    val sameInstance = impl === repo
+    val correctType = repo is RepositoryImpl
+
+    return if (sameInstance && correctType) "OK" else "FAIL: provider function binding not working"
+}

--- a/test-apps/sample-app/src/jvmMain/kotlin/examples/crossmodule/CrossModuleFunctionTest.kt
+++ b/test-apps/sample-app/src/jvmMain/kotlin/examples/crossmodule/CrossModuleFunctionTest.kt
@@ -6,11 +6,13 @@ import org.koin.core.annotation.Module
 import org.koin.core.annotation.Singleton
 
 /**
- * Test cross-module top-level function discovery.
- * This module scans both "featureutil" (cross-module function hint) and "examples.crossmodule" (local).
+ * Test cross-module discovery.
+ * This module scans both "featureutil" (cross-module function hint) and "examples.crossmodule" (local),
+ * and explicitly includes FeatureModule from sample-feature-module to validate cross-Gradle-module
+ * provider function bindings.
  * The function hint from sample-feature-module should make FeatureConfig visible for safety checks.
  */
-@Module
+@Module(includes = [feature.FeatureModule::class])
 @ComponentScan("featureutil", "examples.crossmodule")
 class CrossModuleFunctionModule
 
@@ -20,6 +22,13 @@ class CrossModuleFunctionModule
  */
 @Singleton
 class CrossModuleConsumer(val config: featureutil.FeatureConfig)
+
+/**
+ * A service that depends on FeatureLogger from the cross-module provider function with explicit bindings.
+ * This validates that explicit bindings make FeatureLogger visible for safety checks.
+ */
+@Singleton
+class CrossModuleBoundFunctionConsumer(val logger: feature.FeatureLogger)
 
 @KoinApplication(modules = [CrossModuleFunctionModule::class])
 interface CrossModuleFunctionApp

--- a/test-apps/sample-app/src/jvmTest/kotlin/examples/crossmodule/CrossModuleFunctionTest.kt
+++ b/test-apps/sample-app/src/jvmTest/kotlin/examples/crossmodule/CrossModuleFunctionTest.kt
@@ -21,8 +21,13 @@ class CrossModuleFunctionTest {
         // 1. FIR generated a definition_function_single hint for provideFeatureConfig()
         // 2. IR discovered the hint during CrossModuleFunctionModule's collectAllDefinitions()
         // 3. BindingRegistry validated CrossModuleConsumer's dependency on FeatureConfig as satisfied
+        // 4. FeatureModule is explicitly included from sample-feature-module.
+        // 5. FeatureModule's @Singleton(binds = [FeatureLogger::class]) provider function
+        //    exported its binding metadata for CrossModuleBoundFunctionConsumer.
         // If any of these steps failed, compilation would have produced:
         //   "[Koin] Missing dependency: featureutil.FeatureConfig"
+        // or:
+        //   "[Koin] Missing dependency: feature.FeatureLogger"
         println("Cross-module function hint compile-time validation: OK")
     }
 }

--- a/test-apps/sample-feature-module/src/commonMain/kotlin/feature/FeatureModule.kt
+++ b/test-apps/sample-feature-module/src/commonMain/kotlin/feature/FeatureModule.kt
@@ -14,7 +14,11 @@ import org.koin.core.annotation.Singleton
 @Module
 @ComponentScan
 @Configuration
-class FeatureModule
+class FeatureModule {
+
+    @Singleton(binds = [FeatureLogger::class])
+    internal fun provideFeatureLogger(): FeatureLoggerImpl = FeatureLoggerImpl()
+}
 
 // --- Definitions in this module ---
 
@@ -61,4 +65,18 @@ class PremiumFeatureService {
 @Singleton
 class PremiumConsumer(@Named("premium") val premiumService: PremiumFeatureService) {
     fun consume(): String = premiumService.getPremiumMessage()
+}
+
+/**
+ * A logger defined using binding
+ */
+interface FeatureLogger {
+    fun message(): String
+}
+
+/**
+ * A logger implementation to be bound using supertype
+ */
+internal class FeatureLoggerImpl : FeatureLogger {
+    override fun message(): String = "feature logger"
 }


### PR DESCRIPTION
## Summary

- Preserve explicit `binds` metadata for `@Module` provider functions.
- Apply provider function bindings in generated Koin module DSL calls.
- Export and recover module provider function binding metadata through cross-module hints.
- Add regression coverage for `@Single/@Singleton(binds = [...])` provider functions, including an explicit module include from another Gradle module.

## Validation

- `./install.sh`
- `./gradlew :koin-compiler-plugin:test
- `./gradlew -p test-apps :sample-app:compileKotlinJvm --rerun-tasks`

Fixes #22
