### PR TITLE
2.4.0 beta1 fix

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0-Beta1"
 koin = "4.2.1"
 kotzilla-sdk = "1.4.2"
 build-config = "5.6.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/koin-compiler-plugin/build.gradle.kts
+++ b/koin-compiler-plugin/build.gradle.kts
@@ -92,8 +92,7 @@ kotlin {
         freeCompilerArgs.addAll(
             "-Xsuppress-version-warnings",
             "-Xskip-prerelease-check",
-            "-Xallow-kotlin-package",
-            "-Xcontext-parameters"
+            "-Xallow-kotlin-package"
         )
         // Don't treat warnings as errors
         allWarningsAsErrors.set(false)

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DeprecatedHiddenAnnotation.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DeprecatedHiddenAnnotation.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.expressions.IrAnnotation
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.impl.IrAnnotationImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
@@ -27,16 +28,19 @@ import org.jetbrains.kotlin.name.StandardClassIds
  * Mirrors the FIR-phase annotation added by [org.koin.compiler.plugin.fir.KoinModuleFirGenerator.markAsDeprecatedHidden].
  */
 fun IrSimpleFunction.addDeprecatedHiddenAnnotation(context: IrPluginContext) {
-    val annotation = buildDeprecatedHiddenAnnotation(context) ?: return
-    annotations = annotations + annotation
+    val deprecatedHiddenAnnotation = buildDeprecatedHiddenAnnotation(context) ?: return
+    // In Kotlin version 2.3.20, annotations is a List<IrConstructorCall>
+    // In version 2.4.0,it is a List<IrAnnotation> so we have to make sure
+    // that the cast is correct.
+    annotations = annotations + deprecatedHiddenAnnotation
 }
 
 /**
- * Build an `IrConstructorCall` representing `@Deprecated(message = "...", level = DeprecationLevel.HIDDEN)`.
+ * Build an `IrAnnotation` representing `@Deprecated(message = "...", level = DeprecationLevel.HIDDEN)`.
  * Returns null if the Deprecated class cannot be resolved.
  */
 @OptIn(DeprecatedForRemovalCompilerApi::class)
-private fun buildDeprecatedHiddenAnnotation(context: IrPluginContext): IrConstructorCall? {
+private fun buildDeprecatedHiddenAnnotation(context: IrPluginContext): IrAnnotation? {
     // Resolve kotlin.Deprecated class
     val deprecatedClassSymbol = context.referenceClass(StandardClassIds.Annotations.Deprecated) ?: return null
     val deprecatedClass = deprecatedClassSymbol.owner

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DeprecatedHiddenAnnotation.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DeprecatedHiddenAnnotation.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrAnnotation
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.impl.IrAnnotationImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -16,6 +16,10 @@ import java.util.regex.Pattern;
 @TestMetadata("koin-compiler-plugin/testData/box")
 @TestDataPath("$PROJECT_ROOT")
 public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
+  private void run(String fileName) {
+    runTest("koin-compiler-plugin/testData/box/" + fileName);
+  }
+
   @Test
   public void testAllFilesPresentInBox() {
     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -25,6 +29,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/annotations")
   @TestDataPath("$PROJECT_ROOT")
   public class Annotations {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/annotations/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInAnnotations() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/annotations"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -33,13 +41,13 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("factory_class.kt")
     public void testFactory_class() {
-      runTest("koin-compiler-plugin/testData/box/annotations/factory_class.kt");
+      run("factory_class.kt");
     }
 
     @Test
     @TestMetadata("singleton_class.kt")
     public void testSingleton_class() {
-      runTest("koin-compiler-plugin/testData/box/annotations/singleton_class.kt");
+      run("singleton_class.kt");
     }
   }
 
@@ -47,6 +55,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/bindings")
   @TestDataPath("$PROJECT_ROOT")
   public class Bindings {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/bindings/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInBindings() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/bindings"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -55,13 +67,13 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("auto_interface_binding.kt")
     public void testAuto_interface_binding() {
-      runTest("koin-compiler-plugin/testData/box/bindings/auto_interface_binding.kt");
+      run("auto_interface_binding.kt");
     }
 
     @Test
     @TestMetadata("delegation_no_autobind.kt")
     public void testDelegation_no_autobind() {
-      runTest("koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.kt");
+      run("delegation_no_autobind.kt");
     }
   }
 
@@ -69,6 +81,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/dsl")
   @TestDataPath("$PROJECT_ROOT")
   public class Dsl {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/dsl/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInDsl() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/dsl"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -77,49 +93,49 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("create_constructor.kt")
     public void testCreate_constructor() {
-      runTest("koin-compiler-plugin/testData/box/dsl/create_constructor.kt");
+      run("create_constructor.kt");
     }
 
     @Test
     @TestMetadata("factory_basic.kt")
     public void testFactory_basic() {
-      runTest("koin-compiler-plugin/testData/box/dsl/factory_basic.kt");
+      run("factory_basic.kt");
     }
 
     @Test
     @TestMetadata("scoped_basic.kt")
     public void testScoped_basic() {
-      runTest("koin-compiler-plugin/testData/box/dsl/scoped_basic.kt");
+      run("scoped_basic.kt");
     }
 
     @Test
     @TestMetadata("single_basic.kt")
     public void testSingle_basic() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_basic.kt");
+      run("single_basic.kt");
     }
 
     @Test
     @TestMetadata("single_with_default_value.kt")
     public void testSingle_with_default_value() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_with_default_value.kt");
+      run("single_with_default_value.kt");
     }
 
     @Test
     @TestMetadata("single_with_dependency.kt")
     public void testSingle_with_dependency() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_with_dependency.kt");
+      run("single_with_dependency.kt");
     }
 
     @Test
     @TestMetadata("single_with_lazy.kt")
     public void testSingle_with_lazy() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_with_lazy.kt");
+      run("single_with_lazy.kt");
     }
 
     @Test
     @TestMetadata("single_with_nullable.kt")
     public void testSingle_with_nullable() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_with_nullable.kt");
+      run("single_with_nullable.kt");
     }
   }
 
@@ -127,6 +143,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/modules")
   @TestDataPath("$PROJECT_ROOT")
   public class Modules {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/modules/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInModules() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/modules"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -135,19 +155,19 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("component_scan_basic.kt")
     public void testComponent_scan_basic() {
-      runTest("koin-compiler-plugin/testData/box/modules/component_scan_basic.kt");
+      run("component_scan_basic.kt");
     }
 
     @Test
     @TestMetadata("module_extension.kt")
     public void testModule_extension() {
-      runTest("koin-compiler-plugin/testData/box/modules/module_extension.kt");
+      run("module_extension.kt");
     }
 
     @Test
     @TestMetadata("module_with_functions.kt")
     public void testModule_with_functions() {
-      runTest("koin-compiler-plugin/testData/box/modules/module_with_functions.kt");
+      run("module_with_functions.kt");
     }
   }
 
@@ -155,6 +175,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/monitor")
   @TestDataPath("$PROJECT_ROOT")
   public class Monitor {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/monitor/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInMonitor() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/monitor"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -163,13 +187,13 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("monitor_class.kt")
     public void testMonitor_class() {
-      runTest("koin-compiler-plugin/testData/box/monitor/monitor_class.kt");
+      run("monitor_class.kt");
     }
 
     @Test
     @TestMetadata("monitor_function.kt")
     public void testMonitor_function() {
-      runTest("koin-compiler-plugin/testData/box/monitor/monitor_function.kt");
+      run("monitor_function.kt");
     }
   }
 
@@ -177,6 +201,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/params")
   @TestDataPath("$PROJECT_ROOT")
   public class Params {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/params/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInParams() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/params"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -185,19 +213,19 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("injected_param.kt")
     public void testInjected_param() {
-      runTest("koin-compiler-plugin/testData/box/params/injected_param.kt");
+      run("injected_param.kt");
     }
 
     @Test
     @TestMetadata("lazy_injection.kt")
     public void testLazy_injection() {
-      runTest("koin-compiler-plugin/testData/box/params/lazy_injection.kt");
+      run("lazy_injection.kt");
     }
 
     @Test
     @TestMetadata("property_basic.kt")
     public void testProperty_basic() {
-      runTest("koin-compiler-plugin/testData/box/params/property_basic.kt");
+      run("property_basic.kt");
     }
   }
 
@@ -205,6 +233,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/qualifiers")
   @TestDataPath("$PROJECT_ROOT")
   public class Qualifiers {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/qualifiers/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInQualifiers() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/qualifiers"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -213,19 +245,19 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("named_on_class.kt")
     public void testNamed_on_class() {
-      runTest("koin-compiler-plugin/testData/box/qualifiers/named_on_class.kt");
+      run("named_on_class.kt");
     }
 
     @Test
     @TestMetadata("named_on_parameter.kt")
     public void testNamed_on_parameter() {
-      runTest("koin-compiler-plugin/testData/box/qualifiers/named_on_parameter.kt");
+      run("named_on_parameter.kt");
     }
 
     @Test
     @TestMetadata("qualifier_type.kt")
     public void testQualifier_type() {
-      runTest("koin-compiler-plugin/testData/box/qualifiers/qualifier_type.kt");
+      run("qualifier_type.kt");
     }
   }
 
@@ -233,6 +265,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/safety")
   @TestDataPath("$PROJECT_ROOT")
   public class Safety {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/safety/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInSafety() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/safety"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -241,157 +277,157 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("complete_graph.kt")
     public void testComplete_graph() {
-      runTest("koin-compiler-plugin/testData/box/safety/complete_graph.kt");
+      run("complete_graph.kt");
     }
 
     @Test
     @TestMetadata("configuration_group.kt")
     public void testConfiguration_group() {
-      runTest("koin-compiler-plugin/testData/box/safety/configuration_group.kt");
+      run("configuration_group.kt");
     }
 
     @Test
     @TestMetadata("default_value_ok.kt")
     public void testDefault_value_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/default_value_ok.kt");
+      run("default_value_ok.kt");
     }
 
     @Test
     @TestMetadata("dsl_create_function.kt")
     public void testDsl_create_function() {
-      runTest("koin-compiler-plugin/testData/box/safety/dsl_create_function.kt");
+      run("dsl_create_function.kt");
     }
 
     @Test
     @TestMetadata("dsl_module_includes.kt")
     public void testDsl_module_includes() {
-      runTest("koin-compiler-plugin/testData/box/safety/dsl_module_includes.kt");
+      run("dsl_module_includes.kt");
     }
 
     @Test
     @TestMetadata("dsl_transitive_includes.kt")
     public void testDsl_transitive_includes() {
-      runTest("koin-compiler-plugin/testData/box/safety/dsl_transitive_includes.kt");
+      run("dsl_transitive_includes.kt");
     }
 
     @Test
     @TestMetadata("injected_param_ok.kt")
     public void testInjected_param_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/injected_param_ok.kt");
+      run("injected_param_ok.kt");
     }
 
     @Test
     @TestMetadata("lazy_valid.kt")
     public void testLazy_valid() {
-      runTest("koin-compiler-plugin/testData/box/safety/lazy_valid.kt");
+      run("lazy_valid.kt");
     }
 
     @Test
     @TestMetadata("list_ok.kt")
     public void testList_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/list_ok.kt");
+      run("list_ok.kt");
     }
 
     @Test
     @TestMetadata("module_includes_chain.kt")
     public void testModule_includes_chain() {
-      runTest("koin-compiler-plugin/testData/box/safety/module_includes_chain.kt");
+      run("module_includes_chain.kt");
     }
 
     @Test
     @TestMetadata("module_includes_visible.kt")
     public void testModule_includes_visible() {
-      runTest("koin-compiler-plugin/testData/box/safety/module_includes_visible.kt");
+      run("module_includes_visible.kt");
     }
 
     @Test
     @TestMetadata("nullable_ok.kt")
     public void testNullable_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/nullable_ok.kt");
+      run("nullable_ok.kt");
     }
 
     @Test
     @TestMetadata("property_value_ok.kt")
     public void testProperty_value_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/property_value_ok.kt");
+      run("property_value_ok.kt");
     }
 
     @Test
     @TestMetadata("provided_param_dsl_ok.kt")
     public void testProvided_param_dsl_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/provided_param_dsl_ok.kt");
+      run("provided_param_dsl_ok.kt");
     }
 
     @Test
     @TestMetadata("provided_param_ok.kt")
     public void testProvided_param_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/provided_param_ok.kt");
+      run("provided_param_ok.kt");
     }
 
     @Test
     @TestMetadata("provided_type_ok.kt")
     public void testProvided_type_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/provided_type_ok.kt");
+      run("provided_type_ok.kt");
     }
 
     @Test
     @TestMetadata("qualifier_cross_module.kt")
     public void testQualifier_cross_module() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualifier_cross_module.kt");
+      run("qualifier_cross_module.kt");
     }
 
     @Test
     @TestMetadata("qualifier_cross_module_type.kt")
     public void testQualifier_cross_module_type() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.kt");
+      run("qualifier_cross_module_type.kt");
     }
 
     @Test
     @TestMetadata("qualifier_dotted_name.kt")
     public void testQualifier_dotted_name() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.kt");
+      run("qualifier_dotted_name.kt");
     }
 
     @Test
     @TestMetadata("qualifier_match.kt")
     public void testQualifier_match() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualifier_match.kt");
+      run("qualifier_match.kt");
     }
 
     @Test
     @TestMetadata("scope_id_ok.kt")
     public void testScope_id_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/scope_id_ok.kt");
+      run("scope_id_ok.kt");
     }
 
     @Test
     @TestMetadata("scope_param_dsl_ok.kt")
     public void testScope_param_dsl_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/scope_param_dsl_ok.kt");
+      run("scope_param_dsl_ok.kt");
     }
 
     @Test
     @TestMetadata("scope_param_ok.kt")
     public void testScope_param_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/scope_param_ok.kt");
+      run("scope_param_ok.kt");
     }
 
     @Test
     @TestMetadata("scoped_visibility.kt")
     public void testScoped_visibility() {
-      runTest("koin-compiler-plugin/testData/box/safety/scoped_visibility.kt");
+      run("scoped_visibility.kt");
     }
 
     @Test
     @TestMetadata("startkoin_full_graph.kt")
     public void testStartkoin_full_graph() {
-      runTest("koin-compiler-plugin/testData/box/safety/startkoin_full_graph.kt");
+      run("startkoin_full_graph.kt");
     }
 
     @Test
     @TestMetadata("toplevel_function_ok.kt")
     public void testToplevel_function_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/toplevel_function_ok.kt");
+      run("toplevel_function_ok.kt");
     }
   }
 
@@ -399,6 +435,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/scopes")
   @TestDataPath("$PROJECT_ROOT")
   public class Scopes {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/scopes/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInScopes() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/scopes"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -407,7 +447,7 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("scope_class.kt")
     public void testScope_class() {
-      runTest("koin-compiler-plugin/testData/box/scopes/scope_class.kt");
+      run("scope_class.kt");
     }
   }
 
@@ -415,6 +455,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/startkoin")
   @TestDataPath("$PROJECT_ROOT")
   public class Startkoin {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/startkoin/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInStartkoin() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/startkoin"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -423,25 +467,25 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("configuration_discovery.kt")
     public void testConfiguration_discovery() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/configuration_discovery.kt");
+      run("configuration_discovery.kt");
     }
 
     @Test
     @TestMetadata("koin_application.kt")
     public void testKoin_application() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/koin_application.kt");
+      run("koin_application.kt");
     }
 
     @Test
     @TestMetadata("multiple_modules.kt")
     public void testMultiple_modules() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/multiple_modules.kt");
+      run("multiple_modules.kt");
     }
 
     @Test
     @TestMetadata("startkoin_basic.kt")
     public void testStartkoin_basic() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/startkoin_basic.kt");
+      run("startkoin_basic.kt");
     }
   }
 
@@ -449,6 +493,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/toplevel")
   @TestDataPath("$PROJECT_ROOT")
   public class Toplevel {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/toplevel/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInToplevel() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/toplevel"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -457,7 +505,7 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("singleton_function.kt")
     public void testSingleton_function() {
-      runTest("koin-compiler-plugin/testData/box/toplevel/singleton_function.kt");
+      run("singleton_function.kt");
     }
   }
 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmDiagnosticTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmDiagnosticTestGenerated.java
@@ -15,6 +15,10 @@ import java.util.regex.Pattern;
 @TestMetadata("koin-compiler-plugin/testData/diagnostics")
 @TestDataPath("$PROJECT_ROOT")
 public class JvmDiagnosticTestGenerated extends AbstractJvmDiagnosticTest {
+  private void run(String fileName) {
+    runTest("koin-compiler-plugin/testData/diagnostics/" + fileName);
+  }
+
   @Test
   public void testAllFilesPresentInDiagnostics() {
     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/diagnostics"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -23,54 +27,54 @@ public class JvmDiagnosticTestGenerated extends AbstractJvmDiagnosticTest {
   @Test
   @TestMetadata("configuration_label_mismatch.kt")
   public void testConfiguration_label_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/configuration_label_mismatch.kt");
+    run("configuration_label_mismatch.kt");
   }
 
   @Test
   @TestMetadata("dsl_module_not_loaded.kt")
   public void testDsl_module_not_loaded() {
-    runTest("koin-compiler-plugin/testData/diagnostics/dsl_module_not_loaded.kt");
+    run("dsl_module_not_loaded.kt");
   }
 
   @Test
   @TestMetadata("dsl_module_unreachable.kt")
   public void testDsl_module_unreachable() {
-    runTest("koin-compiler-plugin/testData/diagnostics/dsl_module_unreachable.kt");
+    run("dsl_module_unreachable.kt");
   }
 
   @Test
   @TestMetadata("lazy_missing.kt")
   public void testLazy_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/lazy_missing.kt");
+    run("lazy_missing.kt");
   }
 
   @Test
   @TestMetadata("missing_dependency.kt")
   public void testMissing_dependency() {
-    runTest("koin-compiler-plugin/testData/diagnostics/missing_dependency.kt");
+    run("missing_dependency.kt");
   }
 
   @Test
   @TestMetadata("provided_missing.kt")
   public void testProvided_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/provided_missing.kt");
+    run("provided_missing.kt");
   }
 
   @Test
   @TestMetadata("qualifier_mismatch.kt")
   public void testQualifier_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/qualifier_mismatch.kt");
+    run("qualifier_mismatch.kt");
   }
 
   @Test
   @TestMetadata("scoped_cross_scope.kt")
   public void testScoped_cross_scope() {
-    runTest("koin-compiler-plugin/testData/diagnostics/scoped_cross_scope.kt");
+    run("scoped_cross_scope.kt");
   }
 
   @Test
   @TestMetadata("startkoin_missing.kt")
   public void testStartkoin_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/startkoin_missing.kt");
+    run("startkoin_missing.kt");
   }
 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmErrorMessageTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmErrorMessageTestGenerated.java
@@ -15,6 +15,10 @@ import java.util.regex.Pattern;
 @TestMetadata("koin-compiler-plugin/testData/diagnostics")
 @TestDataPath("$PROJECT_ROOT")
 public class JvmErrorMessageTestGenerated extends AbstractJvmErrorMessageTest {
+  private void run(String fileName) {
+    runTest("koin-compiler-plugin/testData/diagnostics/" + fileName);
+  }
+
   @Test
   public void testAllFilesPresentInDiagnostics() {
     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/diagnostics"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -23,54 +27,54 @@ public class JvmErrorMessageTestGenerated extends AbstractJvmErrorMessageTest {
   @Test
   @TestMetadata("configuration_label_mismatch.kt")
   public void testConfiguration_label_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/configuration_label_mismatch.kt");
+    run("configuration_label_mismatch.kt");
   }
 
   @Test
   @TestMetadata("dsl_module_not_loaded.kt")
   public void testDsl_module_not_loaded() {
-    runTest("koin-compiler-plugin/testData/diagnostics/dsl_module_not_loaded.kt");
+    run("dsl_module_not_loaded.kt");
   }
 
   @Test
   @TestMetadata("dsl_module_unreachable.kt")
   public void testDsl_module_unreachable() {
-    runTest("koin-compiler-plugin/testData/diagnostics/dsl_module_unreachable.kt");
+    run("dsl_module_unreachable.kt");
   }
 
   @Test
   @TestMetadata("lazy_missing.kt")
   public void testLazy_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/lazy_missing.kt");
+    run("lazy_missing.kt");
   }
 
   @Test
   @TestMetadata("missing_dependency.kt")
   public void testMissing_dependency() {
-    runTest("koin-compiler-plugin/testData/diagnostics/missing_dependency.kt");
+    run("missing_dependency.kt");
   }
 
   @Test
   @TestMetadata("provided_missing.kt")
   public void testProvided_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/provided_missing.kt");
+    run("provided_missing.kt");
   }
 
   @Test
   @TestMetadata("qualifier_mismatch.kt")
   public void testQualifier_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/qualifier_mismatch.kt");
+    run("qualifier_mismatch.kt");
   }
 
   @Test
   @TestMetadata("scoped_cross_scope.kt")
   public void testScoped_cross_scope() {
-    runTest("koin-compiler-plugin/testData/diagnostics/scoped_cross_scope.kt");
+    run("scoped_cross_scope.kt");
   }
 
   @Test
   @TestMetadata("startkoin_missing.kt")
   public void testStartkoin_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/startkoin_missing.kt");
+    run("startkoin_missing.kt");
   }
 }

--- a/koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.fir.txt
+++ b/koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.fir.txt
@@ -13,7 +13,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|(binds = <collectionLiteralCall>()) public final class DecoratedService : R|MyService| {
+    @R|org/koin/core/annotation/Singleton|(binds = <collectionLiteralCall>() [evaluated = <collectionLiteralCall>()]) public final class DecoratedService : R|MyService| {
         public constructor(delegate: R|MyService|): R|DecoratedService| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/dsl/create_constructor.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/create_constructor.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/repositoryDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/serviceDsl_scoped.kt
   FUN name:dsl_scoped visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Repository modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/factory_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/factory_basic.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/myServiceDsl_factory.kt
   FUN name:dsl_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/scoped_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/scoped_basic.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/repositoryDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/scopedServiceDsl_scoped.kt
   FUN name:dsl_scoped visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ScopedService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Repository modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_basic.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/myServiceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_with_default_value.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_with_default_value.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/serviceWithDefaultDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ServiceWithDefault
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ServiceWithDefault modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_with_dependency.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_with_dependency.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/repositoryDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Repository modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_with_lazy.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_with_lazy.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/consumerDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Consumer
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/heavyDepDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.HeavyDep
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Consumer modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_with_nullable.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_with_nullable.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:OptionalDependency modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/modules/component_scan_basic.fir.txt
+++ b/koin-compiler-plugin/testData/box/modules/component_scan_basic.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class ScanModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class ScanModule : R|kotlin/Any| {
         public constructor(): R|testpkg/ScanModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/modules/module_with_functions.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/modules/module_with_functions.fir.ir.txt
@@ -235,14 +235,14 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/functionModuleM
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_functionModule__provideRepository visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_functionModule__provideService visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/params/property_basic.fir.txt
+++ b/koin-compiler-plugin/testData/box/params/property_basic.fir.txt
@@ -6,7 +6,7 @@ FILE: test.kt
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class Config : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Property|(value = String(server.host)) host: R|kotlin/String|, @R|org/koin/core/annotation/Property|(value = String(server.port)) port: R|kotlin/String|): R|Config| {
+        public constructor(@R|org/koin/core/annotation/Property|(value = String(server.host) [evaluated = String(server.host)]) host: R|kotlin/String|, @R|org/koin/core/annotation/Property|(value = String(server.port) [evaluated = String(server.port)]) port: R|kotlin/String|): R|Config| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/qualifiers/named_on_class.fir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/named_on_class.fir.txt
@@ -7,13 +7,13 @@ FILE: test.kt
     }
     public abstract interface Service : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(prod)) public final class ProdService : R|Service| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(prod) [evaluated = String(prod)]) public final class ProdService : R|Service| {
         public constructor(): R|ProdService| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(test)) public final class TestService : R|Service| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(test) [evaluated = String(test)]) public final class TestService : R|Service| {
         public constructor(): R|TestService| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/qualifiers/named_on_parameter.fir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/named_on_parameter.fir.txt
@@ -5,14 +5,14 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(special)) public final class SpecialDependency : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(special) [evaluated = String(special)]) public final class SpecialDependency : R|kotlin/Any| {
         public constructor(): R|SpecialDependency| {
             super<R|kotlin/Any|>()
         }
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class Consumer : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(special)) dep: R|SpecialDependency|): R|Consumer| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(special) [evaluated = String(special)]) dep: R|SpecialDependency|): R|Consumer| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/qualifiers/qualifier_type.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/qualifier_type.fir.ir.txt
@@ -17,7 +17,7 @@ FILE fqName:<root> fileName:/test.kt
     CONSTRUCTOR visibility:public returnType:<root>.Consumer [primary]
       VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.QualifiedService
         annotations:
-          Qualifier(value = CLASS_REFERENCE 'CLASS INTERFACE name:ProdQualifier modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.ProdQualifier>, name = <null>)
+          Qualifier(value = ProdQualifier::class, name = <null>)
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Consumer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
@@ -37,7 +37,7 @@ FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:QualifiedService modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
       Singleton(binds = <null>, createdAtStart = <null>)
-      Qualifier(value = CLASS_REFERENCE 'CLASS INTERFACE name:ProdQualifier modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.ProdQualifier>, name = <null>)
+      Qualifier(value = ProdQualifier::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.QualifiedService
     CONSTRUCTOR visibility:public returnType:<root>.QualifiedService [primary]
       BLOCK_BODY

--- a/koin-compiler-plugin/testData/box/qualifiers/qualifier_type.fir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/qualifier_type.fir.txt
@@ -7,14 +7,14 @@ FILE: test.kt
     }
     public abstract interface ProdQualifier : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|ProdQualifier|)) public final class QualifiedService : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|ProdQualifier|) [evaluated = <getClass>(Q|ProdQualifier|)]) public final class QualifiedService : R|kotlin/Any| {
         public constructor(): R|QualifiedService| {
             super<R|kotlin/Any|>()
         }
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class Consumer : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|ProdQualifier|)) service: R|QualifiedService|): R|Consumer| {
+        public constructor(@R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|ProdQualifier|) [evaluated = <getClass>(Q|ProdQualifier|)]) service: R|QualifiedService|): R|Consumer| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/safety/configuration_group.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/configuration_group.fir.ir.txt
@@ -93,13 +93,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_coreModule.kt
   FUN name:componentscan_coreModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:core.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_serviceModule.kt
   FUN name:componentscan_serviceModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:service.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:service fileName:/service/Service.kt
   CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -200,7 +200,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/coreModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.CoreModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -208,7 +208,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/serviceModuleMo
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.ServiceModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/configuration_group.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/configuration_group.fir.txt
@@ -20,13 +20,13 @@ FILE: Service.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core))) @R|org/koin/core/annotation/Configuration|() public final class CoreModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core)) [evaluated = vararg(String(core))]) @R|org/koin/core/annotation/Configuration|() public final class CoreModule : R|kotlin/Any| {
         public constructor(): R|CoreModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) @R|org/koin/core/annotation/Configuration|() public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) @R|org/koin/core/annotation/Configuration|() public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/dsl_create_function.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_create_function.fir.ir.txt
@@ -4,14 +4,14 @@ FILE fqName:org.koin.plugin.hints fileName:/configDsl_single.kt
     VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:providerOnly index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:appModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/dsl_module_includes.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_module_includes.fir.ir.txt
@@ -3,14 +3,14 @@ FILE fqName:org.koin.plugin.hints fileName:/repositoryDsl_single.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     VALUE_PARAMETER kind:Regular name:module_coreModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:coreModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/dsl_transitive_includes.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_transitive_includes.fir.ir.txt
@@ -3,21 +3,21 @@ FILE fqName:org.koin.plugin.hints fileName:/databaseDsl_single.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Database
     VALUE_PARAMETER kind:Regular name:module_dbModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/repositoryDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     VALUE_PARAMETER kind:Regular name:module_dataModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:dbModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/module_includes_chain.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/module_includes_chain.fir.ir.txt
@@ -88,7 +88,7 @@ FILE fqName:<root> fileName:/infraModuleModule.kt
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      Module(includes = [CLASS_REFERENCE 'CLASS CLASS name:DataModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.DataModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+      Module(includes = [DataModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AppModule
     CONSTRUCTOR visibility:public returnType:<root>.AppModule [primary]
       BLOCK_BODY
@@ -149,7 +149,7 @@ FILE fqName:<root> fileName:/test.kt
         public open fun toString (): kotlin.String declared in kotlin.Any
   CLASS CLASS name:DataModule modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      Module(includes = [CLASS_REFERENCE 'CLASS CLASS name:InfraModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.InfraModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+      Module(includes = [InfraModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.DataModule
     CONSTRUCTOR visibility:public returnType:<root>.DataModule [primary]
       BLOCK_BODY
@@ -290,7 +290,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/appModuleModule
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_appModule__provideService visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.AppService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -298,7 +298,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/dataModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_dataModule__provideRepo visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -306,7 +306,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/infraModuleModu
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_infraModule__provideDb visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Database
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/module_includes_chain.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/module_includes_chain.fir.txt
@@ -33,7 +33,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|InfraModule|))) public final class DataModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|InfraModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|InfraModule|))]) public final class DataModule : R|kotlin/Any| {
         public constructor(): R|DataModule| {
             super<R|kotlin/Any|>()
         }
@@ -43,7 +43,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|DataModule|))) public final class AppModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|DataModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|DataModule|))]) public final class AppModule : R|kotlin/Any| {
         public constructor(): R|AppModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/module_includes_visible.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/module_includes_visible.fir.ir.txt
@@ -56,7 +56,7 @@ FILE fqName:<root> fileName:/infraModuleModule.kt
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      Module(includes = [CLASS_REFERENCE 'CLASS CLASS name:InfraModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.InfraModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+      Module(includes = [InfraModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AppModule
     CONSTRUCTOR visibility:public returnType:<root>.AppModule [primary]
       BLOCK_BODY
@@ -196,7 +196,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/appModuleModule
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_appModule__provideService visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.AppService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -204,7 +204,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/infraModuleModu
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_infraModule__provideDatabase visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Database
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/module_includes_visible.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/module_includes_visible.fir.txt
@@ -15,7 +15,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|InfraModule|))) public final class AppModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|InfraModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|InfraModule|))]) public final class AppModule : R|kotlin/Any| {
         public constructor(): R|AppModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/property_value_ok.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/property_value_ok.fir.txt
@@ -1,8 +1,8 @@
 FILE: test.kt
-    field:@R|org/koin/core/annotation/PropertyValue|(value = String(api.timeout)) public final val defaultApiTimeout: R|kotlin/Int| = Int(30)
+    field:@R|org/koin/core/annotation/PropertyValue|(value = String(api.timeout) [evaluated = String(api.timeout)]) public final val defaultApiTimeout: R|kotlin/Int| = Int(30)
         public get(): R|kotlin/Int|
     @R|org/koin/core/annotation/Factory|() public final class ApiClient : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Property|(value = String(api.timeout)) timeout: R|kotlin/Int|): R|ApiClient| {
+        public constructor(@R|org/koin/core/annotation/Property|(value = String(api.timeout) [evaluated = String(api.timeout)]) timeout: R|kotlin/Int|): R|ApiClient| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/safety/provided_param_dsl_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/provided_param_dsl_ok.fir.ir.txt
@@ -3,7 +3,7 @@ FILE fqName:org.koin.plugin.hints fileName:/serviceDsl_single.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:module_testModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:testModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/qualifier_cross_module.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_cross_module.fir.ir.txt
@@ -153,20 +153,20 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_dataModule.kt
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.Cache
     VALUE_PARAMETER kind:Regular name:qualifier_local index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_dataModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:data.RemoteCache
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.Cache
     VALUE_PARAMETER kind:Regular name:qualifier_remote index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_uiModule.kt
   FUN name:componentscan_uiModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:ui.CacheManager
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
@@ -304,7 +304,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/dataModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.DataModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -312,7 +312,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/uiModuleModule.
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.UiModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/qualifier_cross_module.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_cross_module.fir.txt
@@ -3,13 +3,13 @@ FILE: CacheImpl.kt
 
     public abstract interface Cache : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(local)) public final class LocalCache : R|data/Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(local) [evaluated = String(local)]) public final class LocalCache : R|data/Cache| {
         public constructor(): R|data/LocalCache| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(remote)) public final class RemoteCache : R|data/Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(remote) [evaluated = String(remote)]) public final class RemoteCache : R|data/Cache| {
         public constructor(): R|data/RemoteCache| {
             super<R|kotlin/Any|>()
         }
@@ -19,7 +19,7 @@ FILE: CacheManager.kt
     package ui
 
     @R|org/koin/core/annotation/Singleton|() public final class CacheManager : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(local)) local: R|data/Cache|, @R|org/koin/core/annotation/Named|(value = String(remote)) remote: R|data/Cache|): R|ui/CacheManager| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(local) [evaluated = String(local)]) local: R|data/Cache|, @R|org/koin/core/annotation/Named|(value = String(remote) [evaluated = String(remote)]) remote: R|data/Cache|): R|ui/CacheManager| {
             super<R|kotlin/Any|>()
         }
 
@@ -31,13 +31,13 @@ FILE: CacheManager.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data))) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data)) [evaluated = vararg(String(data))]) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
         public constructor(): R|DataModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui))) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui)) [evaluated = vararg(String(ui))]) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
         public constructor(): R|UiModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:data fileName:/data/CacheImpl.kt
   CLASS CLASS name:LocalCache modality:FINAL visibility:public superTypes:[data.Cache]
     annotations:
       Singleton(binds = <null>, createdAtStart = <null>)
-      Qualifier(value = CLASS_REFERENCE 'CLASS CLASS name:LocalQualifier modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<data.LocalQualifier>, name = <null>)
+      Qualifier(value = LocalQualifier::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:data.LocalCache
     CONSTRUCTOR visibility:public returnType:data.LocalCache [primary]
       BLOCK_BODY
@@ -43,7 +43,7 @@ FILE fqName:data fileName:/data/CacheImpl.kt
   CLASS CLASS name:RemoteCache modality:FINAL visibility:public superTypes:[data.Cache]
     annotations:
       Singleton(binds = <null>, createdAtStart = <null>)
-      Qualifier(value = CLASS_REFERENCE 'CLASS CLASS name:RemoteQualifier modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<data.RemoteQualifier>, name = <null>)
+      Qualifier(value = RemoteQualifier::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:data.RemoteCache
     CONSTRUCTOR visibility:public returnType:data.RemoteCache [primary]
       BLOCK_BODY
@@ -193,20 +193,20 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_dataModule.kt
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.Cache
     VALUE_PARAMETER kind:Regular name:qualifierType index:2 type:data.LocalQualifier
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_dataModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:data.RemoteCache
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.Cache
     VALUE_PARAMETER kind:Regular name:qualifierType index:2 type:data.RemoteQualifier
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_uiModule.kt
   FUN name:componentscan_uiModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:ui.CacheManager
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
@@ -286,10 +286,10 @@ FILE fqName:ui fileName:/ui/CacheManager.kt
     CONSTRUCTOR visibility:public returnType:ui.CacheManager [primary]
       VALUE_PARAMETER kind:Regular name:local index:0 type:data.Cache
         annotations:
-          Qualifier(value = CLASS_REFERENCE 'CLASS CLASS name:LocalQualifier modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<data.LocalQualifier>, name = <null>)
+          Qualifier(value = LocalQualifier::class, name = <null>)
       VALUE_PARAMETER kind:Regular name:remote index:1 type:data.Cache
         annotations:
-          Qualifier(value = CLASS_REFERENCE 'CLASS CLASS name:RemoteQualifier modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<data.RemoteQualifier>, name = <null>)
+          Qualifier(value = RemoteQualifier::class, name = <null>)
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:CacheManager modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
@@ -346,7 +346,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/dataModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.DataModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -354,7 +354,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/uiModuleModule.
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.UiModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.fir.txt
@@ -15,13 +15,13 @@ FILE: CacheImpl.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/LocalQualifier|)) public final class LocalCache : R|data/Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/LocalQualifier|) [evaluated = <getClass>(Q|data/LocalQualifier|)]) public final class LocalCache : R|data/Cache| {
         public constructor(): R|data/LocalCache| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/RemoteQualifier|)) public final class RemoteCache : R|data/Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/RemoteQualifier|) [evaluated = <getClass>(Q|data/RemoteQualifier|)]) public final class RemoteCache : R|data/Cache| {
         public constructor(): R|data/RemoteCache| {
             super<R|kotlin/Any|>()
         }
@@ -31,7 +31,7 @@ FILE: CacheManager.kt
     package ui
 
     @R|org/koin/core/annotation/Singleton|() public final class CacheManager : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/LocalQualifier|)) local: R|data/Cache|, @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/RemoteQualifier|)) remote: R|data/Cache|): R|ui/CacheManager| {
+        public constructor(@R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/LocalQualifier|) [evaluated = <getClass>(Q|data/LocalQualifier|)]) local: R|data/Cache|, @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/RemoteQualifier|) [evaluated = <getClass>(Q|data/RemoteQualifier|)]) remote: R|data/Cache|): R|ui/CacheManager| {
             super<R|kotlin/Any|>()
         }
 
@@ -43,13 +43,13 @@ FILE: CacheManager.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data))) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data)) [evaluated = vararg(String(data))]) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
         public constructor(): R|DataModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui))) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui)) [evaluated = vararg(String(ui))]) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
         public constructor(): R|UiModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.fir.ir.txt
@@ -153,20 +153,20 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_dataModule.kt
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.DataSource
     VALUE_PARAMETER kind:Regular name:qualifier_com$2eexample$2elocal index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_dataModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:data.RemoteDataSource
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.DataSource
     VALUE_PARAMETER kind:Regular name:qualifier_com$2eexample$2eremote index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_uiModule.kt
   FUN name:componentscan_uiModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:ui.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
@@ -304,7 +304,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/dataModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.DataModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -312,7 +312,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/uiModuleModule.
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.UiModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.fir.txt
@@ -3,13 +3,13 @@ FILE: Services.kt
 
     public abstract interface DataSource : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(com.example.local)) public final class LocalDataSource : R|data/DataSource| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(com.example.local) [evaluated = String(com.example.local)]) public final class LocalDataSource : R|data/DataSource| {
         public constructor(): R|data/LocalDataSource| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(com.example.remote)) public final class RemoteDataSource : R|data/DataSource| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(com.example.remote) [evaluated = String(com.example.remote)]) public final class RemoteDataSource : R|data/DataSource| {
         public constructor(): R|data/RemoteDataSource| {
             super<R|kotlin/Any|>()
         }
@@ -19,7 +19,7 @@ FILE: Repository.kt
     package ui
 
     @R|org/koin/core/annotation/Singleton|() public final class Repository : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(com.example.local)) local: R|data/DataSource|, @R|org/koin/core/annotation/Named|(value = String(com.example.remote)) remote: R|data/DataSource|): R|ui/Repository| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(com.example.local) [evaluated = String(com.example.local)]) local: R|data/DataSource|, @R|org/koin/core/annotation/Named|(value = String(com.example.remote) [evaluated = String(com.example.remote)]) remote: R|data/DataSource|): R|ui/Repository| {
             super<R|kotlin/Any|>()
         }
 
@@ -31,13 +31,13 @@ FILE: Repository.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data))) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data)) [evaluated = vararg(String(data))]) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
         public constructor(): R|DataModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui))) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui)) [evaluated = vararg(String(ui))]) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
         public constructor(): R|UiModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/qualifier_match.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_match.fir.txt
@@ -7,20 +7,20 @@ FILE: test.kt
     }
     public abstract interface Cache : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(local)) public final class LocalCache : R|Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(local) [evaluated = String(local)]) public final class LocalCache : R|Cache| {
         public constructor(): R|LocalCache| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(remote)) public final class RemoteCache : R|Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(remote) [evaluated = String(remote)]) public final class RemoteCache : R|Cache| {
         public constructor(): R|RemoteCache| {
             super<R|kotlin/Any|>()
         }
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class CacheManager : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(local)) local: R|Cache|, @R|org/koin/core/annotation/Named|(value = String(remote)) remote: R|Cache|): R|CacheManager| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(local) [evaluated = String(local)]) local: R|Cache|, @R|org/koin/core/annotation/Named|(value = String(remote) [evaluated = String(remote)]) remote: R|Cache|): R|CacheManager| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/safety/scope_id_ok.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scope_id_ok.fir.txt
@@ -9,7 +9,7 @@ FILE: test.kt
 
     }
     @R|org/koin/core/annotation/Factory|() public final class ProfileService : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/ScopeId|(name = String(user_session)) session: R|UserSession|): R|ProfileService| {
+        public constructor(@R|org/koin/core/annotation/ScopeId|(name = String(user_session) [evaluated = String(user_session)]) session: R|UserSession|): R|ProfileService| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/safety/scope_param_dsl_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scope_param_dsl_ok.fir.ir.txt
@@ -3,7 +3,7 @@ FILE fqName:org.koin.plugin.hints fileName:/scopeAwareRepositoryDsl_single.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ScopeAwareRepository
     VALUE_PARAMETER kind:Regular name:module_testModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:testModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/scoped_visibility.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scoped_visibility.fir.ir.txt
@@ -23,7 +23,7 @@ FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:SessionData modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
       Scoped(binds = <null>)
-      Scope(value = CLASS_REFERENCE 'CLASS CLASS name:SessionScope modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.SessionScope>, name = <null>)
+      Scope(value = SessionScope::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.SessionData
     PROPERTY name:auth visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:auth type:<root>.AuthService visibility:private [final]

--- a/koin-compiler-plugin/testData/box/safety/scoped_visibility.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scoped_visibility.fir.txt
@@ -17,7 +17,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|SessionScope|)) public final class SessionData : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|SessionScope|) [evaluated = <getClass>(Q|SessionScope|)]) public final class SessionData : R|kotlin/Any| {
         public constructor(auth: R|AuthService|): R|SessionData| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/startkoin_full_graph.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/startkoin_full_graph.fir.ir.txt
@@ -1,7 +1,7 @@
 FILE fqName:<root> fileName:/app.kt
   CLASS OBJECT name:MyApp modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      KoinApplication(configurations = <null>, modules = [CLASS_REFERENCE 'CLASS CLASS name:CoreModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.CoreModule>, CLASS_REFERENCE 'CLASS CLASS name:ServiceModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.ServiceModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>)
+      KoinApplication(configurations = <null>, modules = [CoreModule::class, ServiceModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MyApp
     CONSTRUCTOR visibility:private returnType:<root>.MyApp [primary]
       BLOCK_BODY

--- a/koin-compiler-plugin/testData/box/safety/startkoin_full_graph.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/startkoin_full_graph.fir.txt
@@ -20,20 +20,20 @@ FILE: Service.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core))) public final class CoreModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core)) [evaluated = vararg(String(core))]) public final class CoreModule : R|kotlin/Any| {
         public constructor(): R|CoreModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }
 
     }
 FILE: app.kt
-    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|CoreModule|), <getClass>(Q|ServiceModule|))) public final object MyApp : R|kotlin/Any| {
+    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|CoreModule|), <getClass>(Q|ServiceModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|CoreModule|), <getClass>(Q|ServiceModule|))]) public final object MyApp : R|kotlin/Any| {
         private constructor(): R|MyApp| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/scopes/scope_class.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/scopes/scope_class.fir.ir.txt
@@ -21,7 +21,7 @@ FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ScopedService modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
       Scoped(binds = <null>)
-      Scope(value = CLASS_REFERENCE 'CLASS CLASS name:MyScope modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.MyScope>, name = <null>)
+      Scope(value = MyScope::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.ScopedService
     CONSTRUCTOR visibility:public returnType:<root>.ScopedService [primary]
       BLOCK_BODY

--- a/koin-compiler-plugin/testData/box/scopes/scope_class.fir.txt
+++ b/koin-compiler-plugin/testData/box/scopes/scope_class.fir.txt
@@ -11,7 +11,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|MyScope|)) public final class ScopedService : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|MyScope|) [evaluated = <getClass>(Q|MyScope|)]) public final class ScopedService : R|kotlin/Any| {
         public constructor(): R|ScopedService| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/startkoin/configuration_discovery.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/startkoin/configuration_discovery.fir.ir.txt
@@ -24,7 +24,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_featureModule.kt
   FUN name:componentscan_featureModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.FeatureService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:FeatureModule modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -104,7 +104,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/featureModuleMo
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.FeatureModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/toplevel/singleton_function.fir.txt
+++ b/koin-compiler-plugin/testData/box/toplevel/singleton_function.fir.txt
@@ -12,7 +12,7 @@ FILE: test.kt
     @R|org/koin/core/annotation/Singleton|() public final fun provideDataSource(): R|testpkg/DataSource| {
         ^provideDataSource R|testpkg/DatabaseDataSource.DatabaseDataSource|()
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/configuration_label_mismatch.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/configuration_label_mismatch.fir.txt
@@ -20,13 +20,13 @@ FILE: Service.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core))) @R|org/koin/core/annotation/Configuration|(value = vararg(String(core))) public final class CoreModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core)) [evaluated = vararg(String(core))]) @R|org/koin/core/annotation/Configuration|(value = vararg(String(core)) [evaluated = vararg(String(core))]) public final class CoreModule : R|kotlin/Any| {
         public constructor(): R|CoreModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) @R|org/koin/core/annotation/Configuration|(value = vararg(String(service))) public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) @R|org/koin/core/annotation/Configuration|(value = vararg(String(service)) [evaluated = vararg(String(service))]) public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/qualifier_mismatch.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/qualifier_mismatch.fir.txt
@@ -5,14 +5,14 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(test)) public final class Repository : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(test) [evaluated = String(test)]) public final class Repository : R|kotlin/Any| {
         public constructor(): R|Repository| {
             super<R|kotlin/Any|>()
         }
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class Service : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(prod)) repo: R|Repository|): R|Service| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(prod) [evaluated = String(prod)]) repo: R|Repository|): R|Service| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/diagnostics/scoped_cross_scope.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/scoped_cross_scope.fir.txt
@@ -17,7 +17,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|SessionScope|)) public final class Service : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|SessionScope|) [evaluated = <getClass>(Q|SessionScope|)]) public final class Service : R|kotlin/Any| {
         public constructor(auth: R|AuthData|): R|Service| {
             super<R|kotlin/Any|>()
         }
@@ -26,7 +26,7 @@ FILE: test.kt
             public get(): R|AuthData|
 
     }
-    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|UserScope|)) public final class AuthData : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|UserScope|) [evaluated = <getClass>(Q|UserScope|)]) public final class AuthData : R|kotlin/Any| {
         public constructor(): R|AuthData| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/startkoin_missing.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/startkoin_missing.fir.txt
@@ -17,13 +17,13 @@ FILE: Service.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|ServiceModule|))) public final object MyApp : R|kotlin/Any| {
+    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|ServiceModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|ServiceModule|))]) public final object MyApp : R|kotlin/Any| {
         private constructor(): R|MyApp| {
             super<R|kotlin/Any|>()
         }


### PR DESCRIPTION
**Summary**

When running the compiler plugin when the project uses Kotlin 2.4.0-Beta1, we would get this compiler error:

`error message: java.lang.ClassCastException: class org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter$Companion cannot be cast to class org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor (org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter$Companion and org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor are in unnamed module of loader 'app')`

This fix is to change the return type of buildDeprecatedHiddenAnnotation() from IrConstructorCall? to IrAnnotation? as the abstract annotations type changes from List<IrConstructorCall> in Kotlin 2.3.20 to List<IrAnnotation> in version 2.4.0-Beta1, causing the cast error.

Since IrAnnotation inherits from IrConstructorCall, the cast also works with version 2.3.20, so a side benefit is that this fix is a backwards-compatible change and the plugin will work with Kotlin 2.3.20 projects, even though the plugin is compiled with version 2.4.0-Beta1.

I've also updated the golden files to match the 2.4.0-Beta1 output. There were minimum changes in the outputs with the new version of Kotlin, and all the tests pass. I've tested locally with a project compiled with both 2.4.0-Beta1 and 2.3.20.