### PR TITLE
Fix outer DSL qualifier propagation for `create(::...)` safety hints

### DIFF
--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinDSLTransformer.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinDSLTransformer.kt
@@ -110,6 +110,7 @@ class KoinDSLTransformer(
         // When set, an inner `create(::Impl)` provides T, not Impl — Impl is the
         // construction detail, T is what runtime Koin actually registers.
         val definitionCallTypeArg: IrClass? = null,
+        val definitionQualifier: QualifierValue? = null,
         val scopeTypeClass: IrClass? = null,
         val createQualifier: QualifierValue? = null,
         val createReturnClass: IrClass? = null,
@@ -268,9 +269,16 @@ class KoinDSLTransformer(
             val outerTypeArg = if (expression.typeArguments.size >= 1) {
                 (expression.getTypeArgumentCompat(0)?.classifierOrNull as? IrClassSymbol)?.owner
             } else null
+            val qualifierIndex = callee.regularParameters.indexOfFirst {
+                it.name.asString() == "qualifier"
+            }
+            val outerQualifier = if (qualifierIndex >= 0) {
+                qualifierExtractor.extractFromExpression(expression.getRegularArgument(qualifierIndex))
+            } else null
             transformContext = transformContext.copy(
                 definitionCall = functionName,
-                definitionCallTypeArg = outerTypeArg
+                definitionQualifier = outerQualifier,
+                definitionCallTypeArg = outerTypeArg,
             )
         }
 
@@ -726,7 +734,7 @@ class KoinDSLTransformer(
                 // IC: file containing create(::T) depends on the target class
                 trackClassLookup(lookupTracker, currentFile, targetClass)
                 // Extract qualifier from class for propagation to enclosing definition
-                val classQualifier = qualifierExtractor.extractFromClass(targetClass)
+                val classQualifier = transformContext.definitionQualifier ?: qualifierExtractor.extractFromClass(targetClass)
                 if (classQualifier != null && currentDefinitionCall != null) {
                     transformContext = transformContext.copy(createQualifier = classQualifier, createReturnClass = targetClass)
                 }
@@ -762,7 +770,8 @@ class KoinDSLTransformer(
             is IrSimpleFunction -> {
                 // Extract qualifier from function for propagation to enclosing definition
                 val returnTypeClass = referencedFunction.returnType.classifierOrNull?.owner as? IrClass
-                val funcQualifier = qualifierExtractor.extractFromDeclaration(referencedFunction, "function ${referencedFunction.name}")
+                val funcQualifier = transformContext.definitionQualifier
+                    ?: qualifierExtractor.extractFromDeclaration(referencedFunction, "function ${referencedFunction.name}")
                 if (funcQualifier != null && currentDefinitionCall != null) {
                     transformContext = transformContext.copy(
                         createQualifier = funcQualifier,

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/QualifierExtractor.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/QualifierExtractor.kt
@@ -14,8 +14,10 @@ import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.isString
@@ -209,6 +211,60 @@ class QualifierExtractor(private val context: IrPluginContext) {
 
         // Check for custom qualifier annotations
         return findCustomQualifierAnnotation(param.annotations, "parameter ${param.name}")
+    }
+
+    /**
+     * Extract qualifier from a DSL call argument such as:
+     * - `named("demo")`
+     * - `named<MyQualifier>()`
+     * - `typeQualifier(MyQualifier::class)`
+     * - `typeQualifier<MyQualifier>()`
+     */
+    fun extractFromExpression(expression: IrExpression?): QualifierValue? {
+        val unwrapped = unwrapExpression(expression) ?: return null
+        val call = unwrapped as? IrCall ?: return null
+        val fqName = call.symbol.owner.fqNameWhenAvailable?.asString() ?: return null
+
+        if (fqName == "org.koin.core.qualifier.named") {
+            val stringArg = unwrapExpression(call.getValueArgument(0))
+            if (stringArg is IrConst && stringArg.value is String) {
+                return QualifierValue.StringQualifier(stringArg.value as String)
+            }
+
+            val typeArgClass = call.getTypeArgument(0)?.classifierOrNull?.owner as? IrClass
+            if (typeArgClass != null) {
+                return QualifierValue.TypeQualifier(typeArgClass)
+            }
+        }
+
+        if (fqName == "org.koin.plugin.module.dsl.typeQualifier") {
+            val typeArgClass = call.getTypeArgument(0)?.classifierOrNull?.owner as? IrClass
+            if (typeArgClass != null) {
+                return QualifierValue.TypeQualifier(typeArgClass)
+            }
+
+            val classArg = unwrapExpression(call.getValueArgument(0))
+            if (classArg is IrClassReference) {
+                val qualifierClass = classArg.classType.classifierOrNull?.owner as? IrClass
+                if (qualifierClass != null) {
+                    return QualifierValue.TypeQualifier(qualifierClass)
+                }
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * IR arguments may be wrapped in type-operator nodes such as implicit casts.
+     * Strip those wrappers so we can inspect the underlying call, constant, or class reference.
+     */
+    private fun unwrapExpression(expression: IrExpression?): IrExpression? {
+        var current = expression
+        while (current is IrTypeOperatorCall) {
+            current = current.argument
+        }
+        return current
     }
 
     /**

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -299,6 +299,12 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     }
 
     @Test
+    @TestMetadata("dsl_create_function_outer_qualifier.kt")
+    public void testDsl_create_function_outer_qualifier() {
+      runTest("koin-compiler-plugin/testData/box/safety/dsl_create_function_outer_qualifier.kt");
+    }
+
+    @Test
     @TestMetadata("dsl_injected_param_d006.kt")
     public void testDsl_injected_param_d006() {
       runTest("koin-compiler-plugin/testData/box/safety/dsl_injected_param_d006.kt");

--- a/koin-compiler-plugin/testData/box/safety/dsl_create_function_outer_qualifier.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_create_function_outer_qualifier.fir.ir.txt
@@ -1,0 +1,146 @@
+FILE fqName:org.koin.plugin.hints fileName:/main__demoRootDsl_single.kt
+  FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.DemoRoot
+    VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:providerOnly index:2 type:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:qualifier_Demo1 index:3 type:kotlin.Unit
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:org.koin.plugin.hints fileName:/main__qualifiedConsumerDsl_single.kt
+  FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.QualifiedConsumer
+    VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:<root> fileName:/test.kt
+  PROPERTY name:appModule visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:appModule type:org.koin.core.module.Module visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:$this$module index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                  CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                    TYPE_ARG T: <root>.DemoRoot
+                    ARG <this>: GET_VAR '$this$module: org.koin.core.module.Module declared in <root>.appModule.<anonymous>' type=org.koin.core.module.Module origin=IMPLICIT_ARGUMENT
+                    ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:DemoRoot modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.DemoRoot>
+                    ARG qualifier: CALL 'public final fun named (name: kotlin.String): org.koin.core.qualifier.StringQualifier declared in org.koin.core.qualifier' type=org.koin.core.qualifier.StringQualifier origin=null
+                      ARG name: CONST String type=kotlin.String value="Demo1"
+                    ARG definition: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.DemoRoot> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.DemoRoot
+                        VALUE_PARAMETER kind:ExtensionReceiver name:$this$single index:0 type:org.koin.core.scope.Scope
+                        VALUE_PARAMETER kind:Regular name:it index:1 type:org.koin.core.parameter.ParametersHolder
+                        BLOCK_BODY
+                          RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$single: org.koin.core.scope.Scope, it: org.koin.core.parameter.ParametersHolder): <root>.DemoRoot declared in <root>.appModule.<anonymous>'
+                            CALL 'public final fun createDemoRoot (): <root>.DemoRoot declared in <root>' type=<root>.DemoRoot origin=null
+                TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                  CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                    TYPE_ARG T: <root>.QualifiedConsumer
+                    ARG <this>: GET_VAR '$this$module: org.koin.core.module.Module declared in <root>.appModule.<anonymous>' type=org.koin.core.module.Module origin=IMPLICIT_ARGUMENT
+                    ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:QualifiedConsumer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.QualifiedConsumer>
+                    ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                    ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.QualifiedConsumer> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.QualifiedConsumer
+                        VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                        VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                        BLOCK_BODY
+                          RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.QualifiedConsumer declared in <root>.appModule.<anonymous>'
+                            CONSTRUCTOR_CALL 'public constructor <init> (root: <root>.DemoRoot) declared in <root>.QualifiedConsumer' type=<root>.QualifiedConsumer origin=null
+                              ARG root: CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.scope.Scope.get declared in org.koin.core.scope.Scope' type=<root>.DemoRoot origin=null
+                                TYPE_ARG T: <root>.DemoRoot
+                                ARG <this>: GET_VAR '<this>: org.koin.core.scope.Scope declared in <root>.appModule.<anonymous>.<anonymous>' type=org.koin.core.scope.Scope origin=null
+                                ARG qualifier: CALL 'public final fun named (name: kotlin.String): org.koin.core.qualifier.StringQualifier declared in org.koin.core.qualifier' type=org.koin.core.qualifier.StringQualifier origin=null
+                                  ARG name: CONST String type=kotlin.String value="Demo1"
+                                ARG parameters: CONST Null type=kotlin.Nothing? value=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-appModule> visibility:public modality:FINAL returnType:org.koin.core.module.Module
+      correspondingProperty: PROPERTY name:appModule visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-appModule> (): org.koin.core.module.Module declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:appModule type:org.koin.core.module.Module visibility:private [final,static]' type=org.koin.core.module.Module origin=null
+  CLASS CLASS name:DemoRoot modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.DemoRoot
+    CONSTRUCTOR visibility:public returnType:<root>.DemoRoot [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:DemoRoot modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:QualifiedConsumer modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.QualifiedConsumer
+    PROPERTY name:root visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:root type:<root>.DemoRoot visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'root: <root>.DemoRoot declared in <root>.QualifiedConsumer.<init>' type=<root>.DemoRoot origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-root> visibility:public modality:FINAL returnType:<root>.DemoRoot
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.QualifiedConsumer
+        correspondingProperty: PROPERTY name:root visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-root> (): <root>.DemoRoot declared in <root>.QualifiedConsumer'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:root type:<root>.DemoRoot visibility:private [final]' type=<root>.DemoRoot origin=null
+              receiver: GET_VAR '<this>: <root>.QualifiedConsumer declared in <root>.QualifiedConsumer.<get-root>' type=<root>.QualifiedConsumer origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.QualifiedConsumer [primary]
+      VALUE_PARAMETER kind:Regular name:root index:0 type:<root>.DemoRoot
+        annotations:
+          Named(value = "Demo1", type = <null>)
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:QualifiedConsumer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: CALL 'public final fun <get-appModule> (): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=GET_PROPERTY
+      VAR name:consumer type:<root>.QualifiedConsumer [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.QualifiedConsumer origin=null
+          TYPE_ARG T: <root>.QualifiedConsumer
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=<root>.DemoRoot
+              CALL 'public final fun <get-root> (): <root>.DemoRoot declared in <root>.QualifiedConsumer' type=<root>.DemoRoot origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val consumer: <root>.QualifiedConsumer declared in <root>.box' type=<root>.QualifiedConsumer origin=null
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CONST String type=kotlin.String value="FAIL"
+  FUN name:createDemoRoot visibility:public modality:FINAL returnType:<root>.DemoRoot
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun createDemoRoot (): <root>.DemoRoot declared in <root>'
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.DemoRoot' type=<root>.DemoRoot origin=null

--- a/koin-compiler-plugin/testData/box/safety/dsl_create_function_outer_qualifier.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_create_function_outer_qualifier.fir.txt
@@ -1,0 +1,44 @@
+FILE: test.kt
+    public final class DemoRoot : R|kotlin/Any| {
+        public constructor(): R|DemoRoot| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final class QualifiedConsumer : R|kotlin/Any| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(Demo1)) root: R|DemoRoot|): R|QualifiedConsumer| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val root: R|DemoRoot| = R|<local>/root|
+            public get(): R|DemoRoot|
+
+    }
+    public final fun createDemoRoot(): R|DemoRoot| {
+        ^createDemoRoot R|/DemoRoot.DemoRoot|()
+    }
+    public final val appModule: R|org/koin/core/module/Module| = R|org/koin/dsl/module|(<L> = module@fun R|org/koin/core/module/Module|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+        this@R|special/anonymous|.R|org/koin/core/module/Module.single|<R|DemoRoot|>(R|org/koin/core/qualifier/named|(String(Demo1)), <L> = single@fun R|org/koin/core/scope/Scope|.<anonymous>(it: R|org/koin/core/parameter/ParametersHolder|): R|DemoRoot| <inline=NoInline>  {
+            ^ this@R|special/anonymous|.R|org/koin/plugin/module/dsl/create|<R|DemoRoot|>(::R|/createDemoRoot|)
+        }
+        )
+        this@R|special/anonymous|.R|org/koin/plugin/module/dsl/single|<R|QualifiedConsumer|>()
+    }
+    )
+        public get(): R|org/koin/core/module/Module|
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/appModule|)
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval consumer: R|QualifiedConsumer| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|QualifiedConsumer|>()
+        ^box when () {
+            (R|<local>/consumer|.R|/QualifiedConsumer.root| is R|DemoRoot|) ->  {
+                String(OK)
+            }
+            else ->  {
+                String(FAIL)
+            }
+        }
+
+    }

--- a/koin-compiler-plugin/testData/box/safety/dsl_create_function_outer_qualifier.kt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_create_function_outer_qualifier.kt
@@ -1,0 +1,29 @@
+// FILE: test.kt
+import org.koin.core.annotation.Named
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import org.koin.plugin.module.dsl.create
+import org.koin.plugin.module.dsl.single
+
+class DemoRoot
+
+class QualifiedConsumer(
+    @Named("Demo1") val root: DemoRoot
+)
+
+fun createDemoRoot(): DemoRoot = DemoRoot()
+
+val appModule = module {
+    single(qualifier = named("Demo1")) { create(::createDemoRoot) }
+    single<QualifiedConsumer>()
+}
+
+fun box(): String {
+    val koin = koinApplication {
+        modules(appModule)
+    }.koin
+
+    val consumer = koin.get<QualifiedConsumer>()
+    return if (consumer.root is DemoRoot) "OK" else "FAIL"
+}


### PR DESCRIPTION
# The Pull Request


Related to https://github.com/InsertKoinIO/koin-compiler-plugin/issues/41.

This PR fixes qualifier collection for `create(::...)` registrations when the qualifier is declared on the enclosing DSL call.

At first, I thought the issue was that `@Named` on the constructor/class was not being collected correctly. After digging into it, I found that the actual missing piece was the outer DSL qualifier:

```kotlin
val appModule = module {
    single(qualifier = named("Demo1")) { create(::createDemoRoot) }
}
```

The runtime registration has a qualifier, but the compiler plugin did not carry that outer qualifier into the collected DSL definition used by compile-safety validation.

I understand that the annotation-first style is already supported and may be the more idiomatic style for the compiler plugin:

```kotlin
@Named("local")
class LocalDatabase : Database

@Named("remote")
class RemoteDatabase : Database

// Use @Named on parameters to specify which one to inject
class SyncService(
    @Named("local") val localDb: Database,
    @Named("remote") val remoteDb: Database
)

// DSL - plugin reads @Named from classes and parameters
val appModule = module {
    single<LocalDatabase>()
    single<RemoteDatabase>()
    single<SyncService>()
}
```

However, for users coming from classic Koin DSL, putting the qualifier on the registration site is also a natural style:

```kotlin
single(qualifier = named("local")) { create(::LocalDatabase) }
single(qualifier = named("remote")) { create(::RemoteDatabase) }
```

I am not fully sure whether supporting this style fits the intended design of the Koin compiler plugin. If this goes against the project direction, please feel free to close the PR.

With this change, both forms are supported:

- qualifier declared on the outer DSL call
- qualifier declared on the target class/function via `@Named` / `@Qualifier`

When both are present, the outer DSL qualifier takes priority, matching the actual DSL registration site.


## Changes

- Capture the qualifier from the enclosing DSL definition call.
- Reuse that qualifier when collecting `DslDef` entries from `create(::constructor)` and `create(::function)`.
- Add a box regression test for `single(qualifier = named(...)) { create(::function) }`.

## Verification

```bash
./gradlew :koin-compiler-plugin:test --tests org.jetbrains.kotlin.compiler.plugin.template.runners.JvmBoxTestGenerated\$Safety.testDsl_create_function_outer_qualifier
```