### PR TITLE
Add Kotlin 2.4.0 and AGP 9.2.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A native Kotlin Compiler Plugin for [Koin](https://insert-koin.io/) dependency i
 ```kotlin
 // build.gradle.kts
 plugins {
-    id("io.insert-koin.compiler.plugin") version "1.0.0"
+    id("io.insert-koin.compiler.plugin") version "1.0.1"
 }
 
 dependencies {
@@ -90,7 +90,7 @@ koinCompiler {
 ## Compatibility
 
 - **Koin**: 4.2.0-RC1+
-- **Kotlin**: K2 compiler required (2.3.x+)
+- **Kotlin**: K2 compiler required (2.3.20+), tested through 2.4.0
 
 ## Documentation
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 koin = "4.2.1"
 kotzilla-sdk = "1.4.2"
 build-config = "5.6.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/koin-compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/runners/AbstractJvmBoxTest.kt
+++ b/koin-compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/runners/AbstractJvmBoxTest.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlin.compiler.plugin.template.runners
 import org.jetbrains.kotlin.compiler.plugin.template.services.configurePlugin
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.backend.handlers.UpdateTestDataHandler
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
 import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
@@ -36,6 +37,7 @@ open class AbstractJvmBoxTest : AbstractFirBlackBoxCodegenTestBase(FirParser.Lig
             +CodegenTestDirectives.IGNORE_DEXING // Avoids loading R8 from the classpath.
         }
 
+        useAfterAnalysisCheckers(::UpdateTestDataHandler)
         configurePlugin()
     }
 }

--- a/koin-compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/runners/AbstractJvmDiagnosticTest.kt
+++ b/koin-compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/runners/AbstractJvmDiagnosticTest.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlin.compiler.plugin.template.runners
 
 import org.jetbrains.kotlin.compiler.plugin.template.services.configurePlugin
+import org.jetbrains.kotlin.test.backend.handlers.UpdateTestDataHandler
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
@@ -35,6 +36,7 @@ open class AbstractJvmDiagnosticTest : AbstractFirPhasedDiagnosticTest(FirParser
             +CodegenTestDirectives.IGNORE_DEXING // Avoids loading R8 from the classpath.
         }
 
+        useAfterAnalysisCheckers(::UpdateTestDataHandler)
         configurePlugin()
     }
 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -16,6 +16,10 @@ import java.util.regex.Pattern;
 @TestMetadata("koin-compiler-plugin/testData/box")
 @TestDataPath("$PROJECT_ROOT")
 public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
+  private void run(String fileName) {
+    runTest("koin-compiler-plugin/testData/box/" + fileName);
+  }
+
   @Test
   public void testAllFilesPresentInBox() {
     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -25,6 +29,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/annotations")
   @TestDataPath("$PROJECT_ROOT")
   public class Annotations {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/annotations/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInAnnotations() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/annotations"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -33,19 +41,19 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("factory_class.kt")
     public void testFactory_class() {
-      runTest("koin-compiler-plugin/testData/box/annotations/factory_class.kt");
+      run("factory_class.kt");
     }
 
     @Test
     @TestMetadata("module_created_at_start.kt")
     public void testModule_created_at_start() {
-      runTest("koin-compiler-plugin/testData/box/annotations/module_created_at_start.kt");
+      run("module_created_at_start.kt");
     }
 
     @Test
     @TestMetadata("singleton_class.kt")
     public void testSingleton_class() {
-      runTest("koin-compiler-plugin/testData/box/annotations/singleton_class.kt");
+      run("singleton_class.kt");
     }
   }
 
@@ -53,6 +61,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/bindings")
   @TestDataPath("$PROJECT_ROOT")
   public class Bindings {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/bindings/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInBindings() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/bindings"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -61,19 +73,19 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("auto_interface_binding.kt")
     public void testAuto_interface_binding() {
-      runTest("koin-compiler-plugin/testData/box/bindings/auto_interface_binding.kt");
+      run("auto_interface_binding.kt");
     }
 
     @Test
     @TestMetadata("delegation_no_autobind.kt")
     public void testDelegation_no_autobind() {
-      runTest("koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.kt");
+      run("delegation_no_autobind.kt");
     }
 
     @Test
     @TestMetadata("provider_function_binds.kt")
     public void testProvider_function_binds() {
-      runTest("koin-compiler-plugin/testData/box/bindings/provider_function_binds.kt");
+      run("provider_function_binds.kt");
     }
   }
 
@@ -81,6 +93,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/dsl")
   @TestDataPath("$PROJECT_ROOT")
   public class Dsl {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/dsl/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInDsl() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/dsl"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -89,61 +105,61 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("arrow_bind_non_koin.kt")
     public void testArrow_bind_non_koin() {
-      runTest("koin-compiler-plugin/testData/box/dsl/arrow_bind_non_koin.kt");
+      run("arrow_bind_non_koin.kt");
     }
 
     @Test
     @TestMetadata("create_constructor.kt")
     public void testCreate_constructor() {
-      runTest("koin-compiler-plugin/testData/box/dsl/create_constructor.kt");
+      run("create_constructor.kt");
     }
 
     @Test
     @TestMetadata("factory_basic.kt")
     public void testFactory_basic() {
-      runTest("koin-compiler-plugin/testData/box/dsl/factory_basic.kt");
+      run("factory_basic.kt");
     }
 
     @Test
     @TestMetadata("hints_package_no_annotations.kt")
     public void testHints_package_no_annotations() {
-      runTest("koin-compiler-plugin/testData/box/dsl/hints_package_no_annotations.kt");
+      run("hints_package_no_annotations.kt");
     }
 
     @Test
     @TestMetadata("scoped_basic.kt")
     public void testScoped_basic() {
-      runTest("koin-compiler-plugin/testData/box/dsl/scoped_basic.kt");
+      run("scoped_basic.kt");
     }
 
     @Test
     @TestMetadata("single_basic.kt")
     public void testSingle_basic() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_basic.kt");
+      run("single_basic.kt");
     }
 
     @Test
     @TestMetadata("single_with_default_value.kt")
     public void testSingle_with_default_value() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_with_default_value.kt");
+      run("single_with_default_value.kt");
     }
 
     @Test
     @TestMetadata("single_with_dependency.kt")
     public void testSingle_with_dependency() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_with_dependency.kt");
+      run("single_with_dependency.kt");
     }
 
     @Test
     @TestMetadata("single_with_lazy.kt")
     public void testSingle_with_lazy() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_with_lazy.kt");
+      run("single_with_lazy.kt");
     }
 
     @Test
     @TestMetadata("single_with_nullable.kt")
     public void testSingle_with_nullable() {
-      runTest("koin-compiler-plugin/testData/box/dsl/single_with_nullable.kt");
+      run("single_with_nullable.kt");
     }
   }
 
@@ -151,6 +167,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/modules")
   @TestDataPath("$PROJECT_ROOT")
   public class Modules {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/modules/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInModules() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/modules"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -159,19 +179,19 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("component_scan_basic.kt")
     public void testComponent_scan_basic() {
-      runTest("koin-compiler-plugin/testData/box/modules/component_scan_basic.kt");
+      run("component_scan_basic.kt");
     }
 
     @Test
     @TestMetadata("module_extension.kt")
     public void testModule_extension() {
-      runTest("koin-compiler-plugin/testData/box/modules/module_extension.kt");
+      run("module_extension.kt");
     }
 
     @Test
     @TestMetadata("module_with_functions.kt")
     public void testModule_with_functions() {
-      runTest("koin-compiler-plugin/testData/box/modules/module_with_functions.kt");
+      run("module_with_functions.kt");
     }
   }
 
@@ -179,6 +199,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/monitor")
   @TestDataPath("$PROJECT_ROOT")
   public class Monitor {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/monitor/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInMonitor() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/monitor"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -187,13 +211,13 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("monitor_class.kt")
     public void testMonitor_class() {
-      runTest("koin-compiler-plugin/testData/box/monitor/monitor_class.kt");
+      run("monitor_class.kt");
     }
 
     @Test
     @TestMetadata("monitor_function.kt")
     public void testMonitor_function() {
-      runTest("koin-compiler-plugin/testData/box/monitor/monitor_function.kt");
+      run("monitor_function.kt");
     }
   }
 
@@ -201,6 +225,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/params")
   @TestDataPath("$PROJECT_ROOT")
   public class Params {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/params/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInParams() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/params"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -209,19 +237,19 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("injected_param.kt")
     public void testInjected_param() {
-      runTest("koin-compiler-plugin/testData/box/params/injected_param.kt");
+      run("injected_param.kt");
     }
 
     @Test
     @TestMetadata("lazy_injection.kt")
     public void testLazy_injection() {
-      runTest("koin-compiler-plugin/testData/box/params/lazy_injection.kt");
+      run("lazy_injection.kt");
     }
 
     @Test
     @TestMetadata("property_basic.kt")
     public void testProperty_basic() {
-      runTest("koin-compiler-plugin/testData/box/params/property_basic.kt");
+      run("property_basic.kt");
     }
   }
 
@@ -229,6 +257,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/qualifiers")
   @TestDataPath("$PROJECT_ROOT")
   public class Qualifiers {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/qualifiers/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInQualifiers() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/qualifiers"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -237,25 +269,25 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("custom_qualifier_type.kt")
     public void testCustom_qualifier_type() {
-      runTest("koin-compiler-plugin/testData/box/qualifiers/custom_qualifier_type.kt");
+      run("custom_qualifier_type.kt");
     }
 
     @Test
     @TestMetadata("named_on_class.kt")
     public void testNamed_on_class() {
-      runTest("koin-compiler-plugin/testData/box/qualifiers/named_on_class.kt");
+      run("named_on_class.kt");
     }
 
     @Test
     @TestMetadata("named_on_parameter.kt")
     public void testNamed_on_parameter() {
-      runTest("koin-compiler-plugin/testData/box/qualifiers/named_on_parameter.kt");
+      run("named_on_parameter.kt");
     }
 
     @Test
     @TestMetadata("qualifier_type.kt")
     public void testQualifier_type() {
-      runTest("koin-compiler-plugin/testData/box/qualifiers/qualifier_type.kt");
+      run("qualifier_type.kt");
     }
   }
 
@@ -263,6 +295,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/safety")
   @TestDataPath("$PROJECT_ROOT")
   public class Safety {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/safety/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInSafety() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/safety"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -271,193 +307,193 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("callsite_hint_module_prefix.kt")
     public void testCallsite_hint_module_prefix() {
-      runTest("koin-compiler-plugin/testData/box/safety/callsite_hint_module_prefix.kt");
+      run("callsite_hint_module_prefix.kt");
     }
 
     @Test
     @TestMetadata("complete_graph.kt")
     public void testComplete_graph() {
-      runTest("koin-compiler-plugin/testData/box/safety/complete_graph.kt");
+      run("complete_graph.kt");
     }
 
     @Test
     @TestMetadata("configuration_group.kt")
     public void testConfiguration_group() {
-      runTest("koin-compiler-plugin/testData/box/safety/configuration_group.kt");
+      run("configuration_group.kt");
     }
 
     @Test
     @TestMetadata("default_value_ok.kt")
     public void testDefault_value_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/default_value_ok.kt");
+      run("default_value_ok.kt");
     }
 
     @Test
     @TestMetadata("dsl_create_function.kt")
     public void testDsl_create_function() {
-      runTest("koin-compiler-plugin/testData/box/safety/dsl_create_function.kt");
+      run("dsl_create_function.kt");
     }
 
     @Test
     @TestMetadata("dsl_injected_param_d006.kt")
     public void testDsl_injected_param_d006() {
-      runTest("koin-compiler-plugin/testData/box/safety/dsl_injected_param_d006.kt");
+      run("dsl_injected_param_d006.kt");
     }
 
     @Test
     @TestMetadata("dsl_module_includes.kt")
     public void testDsl_module_includes() {
-      runTest("koin-compiler-plugin/testData/box/safety/dsl_module_includes.kt");
+      run("dsl_module_includes.kt");
     }
 
     @Test
     @TestMetadata("dsl_nested_includes.kt")
     public void testDsl_nested_includes() {
-      runTest("koin-compiler-plugin/testData/box/safety/dsl_nested_includes.kt");
+      run("dsl_nested_includes.kt");
     }
 
     @Test
     @TestMetadata("dsl_transitive_includes.kt")
     public void testDsl_transitive_includes() {
-      runTest("koin-compiler-plugin/testData/box/safety/dsl_transitive_includes.kt");
+      run("dsl_transitive_includes.kt");
     }
 
     @Test
     @TestMetadata("generic_dsl_type_no_crash.kt")
     public void testGeneric_dsl_type_no_crash() {
-      runTest("koin-compiler-plugin/testData/box/safety/generic_dsl_type_no_crash.kt");
+      run("generic_dsl_type_no_crash.kt");
     }
 
     @Test
     @TestMetadata("injected_param_ok.kt")
     public void testInjected_param_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/injected_param_ok.kt");
+      run("injected_param_ok.kt");
     }
 
     @Test
     @TestMetadata("injected_param_unit_qualifier_collision.kt")
     public void testInjected_param_unit_qualifier_collision() {
-      runTest("koin-compiler-plugin/testData/box/safety/injected_param_unit_qualifier_collision.kt");
+      run("injected_param_unit_qualifier_collision.kt");
     }
 
     @Test
     @TestMetadata("lazy_valid.kt")
     public void testLazy_valid() {
-      runTest("koin-compiler-plugin/testData/box/safety/lazy_valid.kt");
+      run("lazy_valid.kt");
     }
 
     @Test
     @TestMetadata("list_ok.kt")
     public void testList_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/list_ok.kt");
+      run("list_ok.kt");
     }
 
     @Test
     @TestMetadata("module_includes_chain.kt")
     public void testModule_includes_chain() {
-      runTest("koin-compiler-plugin/testData/box/safety/module_includes_chain.kt");
+      run("module_includes_chain.kt");
     }
 
     @Test
     @TestMetadata("module_includes_visible.kt")
     public void testModule_includes_visible() {
-      runTest("koin-compiler-plugin/testData/box/safety/module_includes_visible.kt");
+      run("module_includes_visible.kt");
     }
 
     @Test
     @TestMetadata("nullable_ok.kt")
     public void testNullable_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/nullable_ok.kt");
+      run("nullable_ok.kt");
     }
 
     @Test
     @TestMetadata("property_value_ok.kt")
     public void testProperty_value_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/property_value_ok.kt");
+      run("property_value_ok.kt");
     }
 
     @Test
     @TestMetadata("provided_param_dsl_ok.kt")
     public void testProvided_param_dsl_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/provided_param_dsl_ok.kt");
+      run("provided_param_dsl_ok.kt");
     }
 
     @Test
     @TestMetadata("provided_param_ok.kt")
     public void testProvided_param_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/provided_param_ok.kt");
+      run("provided_param_ok.kt");
     }
 
     @Test
     @TestMetadata("provided_type_ok.kt")
     public void testProvided_type_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/provided_type_ok.kt");
+      run("provided_type_ok.kt");
     }
 
     @Test
     @TestMetadata("qualified_function_cross_module.kt")
     public void testQualified_function_cross_module() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualified_function_cross_module.kt");
+      run("qualified_function_cross_module.kt");
     }
 
     @Test
     @TestMetadata("qualifier_cross_module.kt")
     public void testQualifier_cross_module() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualifier_cross_module.kt");
+      run("qualifier_cross_module.kt");
     }
 
     @Test
     @TestMetadata("qualifier_cross_module_type.kt")
     public void testQualifier_cross_module_type() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.kt");
+      run("qualifier_cross_module_type.kt");
     }
 
     @Test
     @TestMetadata("qualifier_dotted_name.kt")
     public void testQualifier_dotted_name() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.kt");
+      run("qualifier_dotted_name.kt");
     }
 
     @Test
     @TestMetadata("qualifier_match.kt")
     public void testQualifier_match() {
-      runTest("koin-compiler-plugin/testData/box/safety/qualifier_match.kt");
+      run("qualifier_match.kt");
     }
 
     @Test
     @TestMetadata("scope_id_ok.kt")
     public void testScope_id_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/scope_id_ok.kt");
+      run("scope_id_ok.kt");
     }
 
     @Test
     @TestMetadata("scope_param_dsl_ok.kt")
     public void testScope_param_dsl_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/scope_param_dsl_ok.kt");
+      run("scope_param_dsl_ok.kt");
     }
 
     @Test
     @TestMetadata("scope_param_ok.kt")
     public void testScope_param_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/scope_param_ok.kt");
+      run("scope_param_ok.kt");
     }
 
     @Test
     @TestMetadata("scoped_visibility.kt")
     public void testScoped_visibility() {
-      runTest("koin-compiler-plugin/testData/box/safety/scoped_visibility.kt");
+      run("scoped_visibility.kt");
     }
 
     @Test
     @TestMetadata("startkoin_full_graph.kt")
     public void testStartkoin_full_graph() {
-      runTest("koin-compiler-plugin/testData/box/safety/startkoin_full_graph.kt");
+      run("startkoin_full_graph.kt");
     }
 
     @Test
     @TestMetadata("toplevel_function_ok.kt")
     public void testToplevel_function_ok() {
-      runTest("koin-compiler-plugin/testData/box/safety/toplevel_function_ok.kt");
+      run("toplevel_function_ok.kt");
     }
   }
 
@@ -465,6 +501,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/scopes")
   @TestDataPath("$PROJECT_ROOT")
   public class Scopes {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/scopes/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInScopes() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/scopes"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -473,19 +513,19 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("scope_class.kt")
     public void testScope_class() {
-      runTest("koin-compiler-plugin/testData/box/scopes/scope_class.kt");
+      run("scope_class.kt");
     }
 
     @Test
     @TestMetadata("scope_id_param_name.kt")
     public void testScope_id_param_name() {
-      runTest("koin-compiler-plugin/testData/box/scopes/scope_id_param_name.kt");
+      run("scope_id_param_name.kt");
     }
 
     @Test
     @TestMetadata("scope_name.kt")
     public void testScope_name() {
-      runTest("koin-compiler-plugin/testData/box/scopes/scope_name.kt");
+      run("scope_name.kt");
     }
   }
 
@@ -493,6 +533,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/startkoin")
   @TestDataPath("$PROJECT_ROOT")
   public class Startkoin {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/startkoin/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInStartkoin() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/startkoin"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -501,31 +545,31 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("configuration_discovery.kt")
     public void testConfiguration_discovery() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/configuration_discovery.kt");
+      run("configuration_discovery.kt");
     }
 
     @Test
     @TestMetadata("explicit_modules_override_configuration.kt")
     public void testExplicit_modules_override_configuration() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/explicit_modules_override_configuration.kt");
+      run("explicit_modules_override_configuration.kt");
     }
 
     @Test
     @TestMetadata("koin_application.kt")
     public void testKoin_application() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/koin_application.kt");
+      run("koin_application.kt");
     }
 
     @Test
     @TestMetadata("multiple_modules.kt")
     public void testMultiple_modules() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/multiple_modules.kt");
+      run("multiple_modules.kt");
     }
 
     @Test
     @TestMetadata("startkoin_basic.kt")
     public void testStartkoin_basic() {
-      runTest("koin-compiler-plugin/testData/box/startkoin/startkoin_basic.kt");
+      run("startkoin_basic.kt");
     }
   }
 
@@ -533,6 +577,10 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   @TestMetadata("koin-compiler-plugin/testData/box/toplevel")
   @TestDataPath("$PROJECT_ROOT")
   public class Toplevel {
+    private void run(String fileName) {
+      runTest("koin-compiler-plugin/testData/box/toplevel/" + fileName);
+    }
+
     @Test
     public void testAllFilesPresentInToplevel() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/toplevel"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -541,13 +589,13 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     @TestMetadata("qualified_unit_singletons.kt")
     public void testQualified_unit_singletons() {
-      runTest("koin-compiler-plugin/testData/box/toplevel/qualified_unit_singletons.kt");
+      run("qualified_unit_singletons.kt");
     }
 
     @Test
     @TestMetadata("singleton_function.kt")
     public void testSingleton_function() {
-      runTest("koin-compiler-plugin/testData/box/toplevel/singleton_function.kt");
+      run("singleton_function.kt");
     }
   }
 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmDiagnosticTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmDiagnosticTestGenerated.java
@@ -15,6 +15,10 @@ import java.util.regex.Pattern;
 @TestMetadata("koin-compiler-plugin/testData/diagnostics")
 @TestDataPath("$PROJECT_ROOT")
 public class JvmDiagnosticTestGenerated extends AbstractJvmDiagnosticTest {
+  private void run(String fileName) {
+    runTest("koin-compiler-plugin/testData/diagnostics/" + fileName);
+  }
+
   @Test
   public void testAllFilesPresentInDiagnostics() {
     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/diagnostics"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -23,138 +27,138 @@ public class JvmDiagnosticTestGenerated extends AbstractJvmDiagnosticTest {
   @Test
   @TestMetadata("call_site_param_arity_mismatch.kt")
   public void testCall_site_param_arity_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_arity_mismatch.kt");
+    run("call_site_param_arity_mismatch.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_dsl_missing_d006.kt")
   public void testCall_site_param_dsl_missing_d006() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_dsl_missing_d006.kt");
+    run("call_site_param_dsl_missing_d006.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_missing_d006.kt")
   public void testCall_site_param_missing_d006() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_missing_d006.kt");
+    run("call_site_param_missing_d006.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_no_injected_no_d006.kt")
   public void testCall_site_param_no_injected_no_d006() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_no_injected_no_d006.kt");
+    run("call_site_param_no_injected_no_d006.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_nullable_ok.kt")
   public void testCall_site_param_nullable_ok() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_nullable_ok.kt");
+    run("call_site_param_nullable_ok.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_ok.kt")
   public void testCall_site_param_ok() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_ok.kt");
+    run("call_site_param_ok.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_type_mismatch.kt")
   public void testCall_site_param_type_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_type_mismatch.kt");
+    run("call_site_param_type_mismatch.kt");
   }
 
   @Test
   @TestMetadata("circular_dependency_broken_by_lazy.kt")
   public void testCircular_dependency_broken_by_lazy() {
-    runTest("koin-compiler-plugin/testData/diagnostics/circular_dependency_broken_by_lazy.kt");
+    run("circular_dependency_broken_by_lazy.kt");
   }
 
   @Test
   @TestMetadata("circular_dependency_direct.kt")
   public void testCircular_dependency_direct() {
-    runTest("koin-compiler-plugin/testData/diagnostics/circular_dependency_direct.kt");
+    run("circular_dependency_direct.kt");
   }
 
   @Test
   @TestMetadata("circular_dependency_transitive.kt")
   public void testCircular_dependency_transitive() {
-    runTest("koin-compiler-plugin/testData/diagnostics/circular_dependency_transitive.kt");
+    run("circular_dependency_transitive.kt");
   }
 
   @Test
   @TestMetadata("configuration_label_mismatch.kt")
   public void testConfiguration_label_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/configuration_label_mismatch.kt");
+    run("configuration_label_mismatch.kt");
   }
 
   @Test
   @TestMetadata("dsl_module_not_loaded.kt")
   public void testDsl_module_not_loaded() {
-    runTest("koin-compiler-plugin/testData/diagnostics/dsl_module_not_loaded.kt");
+    run("dsl_module_not_loaded.kt");
   }
 
   @Test
   @TestMetadata("dsl_module_unreachable.kt")
   public void testDsl_module_unreachable() {
-    runTest("koin-compiler-plugin/testData/diagnostics/dsl_module_unreachable.kt");
+    run("dsl_module_unreachable.kt");
   }
 
   @Test
   @TestMetadata("factory_suspend_fun_interface_d007.kt")
   public void testFactory_suspend_fun_interface_d007() {
-    runTest("koin-compiler-plugin/testData/diagnostics/factory_suspend_fun_interface_d007.kt");
+    run("factory_suspend_fun_interface_d007.kt");
   }
 
   @Test
   @TestMetadata("koin_configuration_modules_a3.kt")
   public void testKoin_configuration_modules_a3() {
-    runTest("koin-compiler-plugin/testData/diagnostics/koin_configuration_modules_a3.kt");
+    run("koin_configuration_modules_a3.kt");
   }
 
   @Test
   @TestMetadata("lazy_missing.kt")
   public void testLazy_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/lazy_missing.kt");
+    run("lazy_missing.kt");
   }
 
   @Test
   @TestMetadata("missing_dependency.kt")
   public void testMissing_dependency() {
-    runTest("koin-compiler-plugin/testData/diagnostics/missing_dependency.kt");
+    run("missing_dependency.kt");
   }
 
   @Test
   @TestMetadata("missing_viewmodel_artifact.kt")
   public void testMissing_viewmodel_artifact() {
-    runTest("koin-compiler-plugin/testData/diagnostics/missing_viewmodel_artifact.kt");
+    run("missing_viewmodel_artifact.kt");
   }
 
   @Test
   @TestMetadata("missing_worker_artifact.kt")
   public void testMissing_worker_artifact() {
-    runTest("koin-compiler-plugin/testData/diagnostics/missing_worker_artifact.kt");
+    run("missing_worker_artifact.kt");
   }
 
   @Test
   @TestMetadata("provided_missing.kt")
   public void testProvided_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/provided_missing.kt");
+    run("provided_missing.kt");
   }
 
   @Test
   @TestMetadata("qualifier_mismatch.kt")
   public void testQualifier_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/qualifier_mismatch.kt");
+    run("qualifier_mismatch.kt");
   }
 
   @Test
   @TestMetadata("scoped_cross_scope.kt")
   public void testScoped_cross_scope() {
-    runTest("koin-compiler-plugin/testData/diagnostics/scoped_cross_scope.kt");
+    run("scoped_cross_scope.kt");
   }
 
   @Test
   @TestMetadata("startkoin_missing.kt")
   public void testStartkoin_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/startkoin_missing.kt");
+    run("startkoin_missing.kt");
   }
 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmErrorMessageTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmErrorMessageTestGenerated.java
@@ -15,6 +15,10 @@ import java.util.regex.Pattern;
 @TestMetadata("koin-compiler-plugin/testData/diagnostics")
 @TestDataPath("$PROJECT_ROOT")
 public class JvmErrorMessageTestGenerated extends AbstractJvmErrorMessageTest {
+  private void run(String fileName) {
+    runTest("koin-compiler-plugin/testData/diagnostics/" + fileName);
+  }
+
   @Test
   public void testAllFilesPresentInDiagnostics() {
     KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/diagnostics"), Pattern.compile("^(.+)\\.kt$"), null, true);
@@ -23,138 +27,138 @@ public class JvmErrorMessageTestGenerated extends AbstractJvmErrorMessageTest {
   @Test
   @TestMetadata("call_site_param_arity_mismatch.kt")
   public void testCall_site_param_arity_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_arity_mismatch.kt");
+    run("call_site_param_arity_mismatch.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_dsl_missing_d006.kt")
   public void testCall_site_param_dsl_missing_d006() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_dsl_missing_d006.kt");
+    run("call_site_param_dsl_missing_d006.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_missing_d006.kt")
   public void testCall_site_param_missing_d006() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_missing_d006.kt");
+    run("call_site_param_missing_d006.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_no_injected_no_d006.kt")
   public void testCall_site_param_no_injected_no_d006() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_no_injected_no_d006.kt");
+    run("call_site_param_no_injected_no_d006.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_nullable_ok.kt")
   public void testCall_site_param_nullable_ok() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_nullable_ok.kt");
+    run("call_site_param_nullable_ok.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_ok.kt")
   public void testCall_site_param_ok() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_ok.kt");
+    run("call_site_param_ok.kt");
   }
 
   @Test
   @TestMetadata("call_site_param_type_mismatch.kt")
   public void testCall_site_param_type_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/call_site_param_type_mismatch.kt");
+    run("call_site_param_type_mismatch.kt");
   }
 
   @Test
   @TestMetadata("circular_dependency_broken_by_lazy.kt")
   public void testCircular_dependency_broken_by_lazy() {
-    runTest("koin-compiler-plugin/testData/diagnostics/circular_dependency_broken_by_lazy.kt");
+    run("circular_dependency_broken_by_lazy.kt");
   }
 
   @Test
   @TestMetadata("circular_dependency_direct.kt")
   public void testCircular_dependency_direct() {
-    runTest("koin-compiler-plugin/testData/diagnostics/circular_dependency_direct.kt");
+    run("circular_dependency_direct.kt");
   }
 
   @Test
   @TestMetadata("circular_dependency_transitive.kt")
   public void testCircular_dependency_transitive() {
-    runTest("koin-compiler-plugin/testData/diagnostics/circular_dependency_transitive.kt");
+    run("circular_dependency_transitive.kt");
   }
 
   @Test
   @TestMetadata("configuration_label_mismatch.kt")
   public void testConfiguration_label_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/configuration_label_mismatch.kt");
+    run("configuration_label_mismatch.kt");
   }
 
   @Test
   @TestMetadata("dsl_module_not_loaded.kt")
   public void testDsl_module_not_loaded() {
-    runTest("koin-compiler-plugin/testData/diagnostics/dsl_module_not_loaded.kt");
+    run("dsl_module_not_loaded.kt");
   }
 
   @Test
   @TestMetadata("dsl_module_unreachable.kt")
   public void testDsl_module_unreachable() {
-    runTest("koin-compiler-plugin/testData/diagnostics/dsl_module_unreachable.kt");
+    run("dsl_module_unreachable.kt");
   }
 
   @Test
   @TestMetadata("factory_suspend_fun_interface_d007.kt")
   public void testFactory_suspend_fun_interface_d007() {
-    runTest("koin-compiler-plugin/testData/diagnostics/factory_suspend_fun_interface_d007.kt");
+    run("factory_suspend_fun_interface_d007.kt");
   }
 
   @Test
   @TestMetadata("koin_configuration_modules_a3.kt")
   public void testKoin_configuration_modules_a3() {
-    runTest("koin-compiler-plugin/testData/diagnostics/koin_configuration_modules_a3.kt");
+    run("koin_configuration_modules_a3.kt");
   }
 
   @Test
   @TestMetadata("lazy_missing.kt")
   public void testLazy_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/lazy_missing.kt");
+    run("lazy_missing.kt");
   }
 
   @Test
   @TestMetadata("missing_dependency.kt")
   public void testMissing_dependency() {
-    runTest("koin-compiler-plugin/testData/diagnostics/missing_dependency.kt");
+    run("missing_dependency.kt");
   }
 
   @Test
   @TestMetadata("missing_viewmodel_artifact.kt")
   public void testMissing_viewmodel_artifact() {
-    runTest("koin-compiler-plugin/testData/diagnostics/missing_viewmodel_artifact.kt");
+    run("missing_viewmodel_artifact.kt");
   }
 
   @Test
   @TestMetadata("missing_worker_artifact.kt")
   public void testMissing_worker_artifact() {
-    runTest("koin-compiler-plugin/testData/diagnostics/missing_worker_artifact.kt");
+    run("missing_worker_artifact.kt");
   }
 
   @Test
   @TestMetadata("provided_missing.kt")
   public void testProvided_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/provided_missing.kt");
+    run("provided_missing.kt");
   }
 
   @Test
   @TestMetadata("qualifier_mismatch.kt")
   public void testQualifier_mismatch() {
-    runTest("koin-compiler-plugin/testData/diagnostics/qualifier_mismatch.kt");
+    run("qualifier_mismatch.kt");
   }
 
   @Test
   @TestMetadata("scoped_cross_scope.kt")
   public void testScoped_cross_scope() {
-    runTest("koin-compiler-plugin/testData/diagnostics/scoped_cross_scope.kt");
+    run("scoped_cross_scope.kt");
   }
 
   @Test
   @TestMetadata("startkoin_missing.kt")
   public void testStartkoin_missing() {
-    runTest("koin-compiler-plugin/testData/diagnostics/startkoin_missing.kt");
+    run("startkoin_missing.kt");
   }
 }

--- a/koin-compiler-plugin/testData/box/annotations/factory_class.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/factory_class.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyFactory
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:MyFactory modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/annotations/module_created_at_start.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/module_created_at_start.fir.ir.txt
@@ -2,12 +2,12 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.EagerService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.LazyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:EagerService modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/annotations/module_created_at_start.fir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/module_created_at_start.fir.txt
@@ -18,7 +18,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|(createdAtStart = Boolean(true)) public final class EagerService : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Singleton|(createdAtStart = Boolean(true) [evaluated = Boolean(true)]) public final class EagerService : R|kotlin/Any| {
         public constructor(): R|EagerService| {
             super<R|kotlin/Any|>()
         }
@@ -48,7 +48,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Module|(createdAtStart = Boolean(true)) @R|org/koin/core/annotation/ComponentScan|() public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|(createdAtStart = Boolean(true) [evaluated = Boolean(true)]) @R|org/koin/core/annotation/ComponentScan|() public final class TestModule : R|kotlin/Any| {
         public constructor(): R|TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/annotations/singleton_class.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/singleton_class.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MySingleton
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:MySingleton modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/bindings/auto_interface_binding.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/bindings/auto_interface_binding.fir.ir.txt
@@ -3,7 +3,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.RepositoryImpl
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:RepositoryImpl modality:FINAL visibility:public superTypes:[<root>.Repository]

--- a/koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.DecoratedService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.RealService
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.MyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:DecoratedService modality:FINAL visibility:public superTypes:[<root>.MyService]

--- a/koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.fir.txt
+++ b/koin-compiler-plugin/testData/box/bindings/delegation_no_autobind.fir.txt
@@ -13,7 +13,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|(binds = <collectionLiteralCall>()) public final class DecoratedService : R|MyService| {
+    @R|org/koin/core/annotation/Singleton|(binds = <collectionLiteralCall>() [evaluated = <collectionLiteralCall>()]) public final class DecoratedService : R|MyService| {
         public constructor(delegate: R|MyService|): R|DecoratedService| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/bindings/provider_function_binds.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/bindings/provider_function_binds.fir.ir.txt
@@ -42,7 +42,7 @@ FILE fqName:<root> fileName:/test.kt
     FUN name:provideRepository visibility:public modality:FINAL returnType:<root>.RepositoryImpl
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestModule
       annotations:
-        Single(binds = [CLASS_REFERENCE 'CLASS INTERFACE name:Repository modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Repository>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+        Single(binds = [Repository::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun provideRepository (): <root>.RepositoryImpl declared in <root>.TestModule'
           CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.RepositoryImpl' type=<root>.RepositoryImpl origin=null
@@ -135,7 +135,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/testModuleModul
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.RepositoryImpl
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:binding0 index:1 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/bindings/provider_function_binds.fir.txt
+++ b/koin-compiler-plugin/testData/box/bindings/provider_function_binds.fir.txt
@@ -4,7 +4,7 @@ FILE: test.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|org/koin/core/annotation/Single|(binds = <collectionLiteralCall>(<getClass>(Q|Repository|))) public final fun provideRepository(): R|RepositoryImpl| {
+        @R|org/koin/core/annotation/Single|(binds = <collectionLiteralCall>(<getClass>(Q|Repository|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|Repository|))]) public final fun provideRepository(): R|RepositoryImpl| {
             ^provideRepository R|/RepositoryImpl.RepositoryImpl|()
         }
 

--- a/koin-compiler-plugin/testData/box/dsl/arrow_bind_non_koin.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/arrow_bind_non_koin.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Boxed modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/create_constructor.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/create_constructor.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/main__repositoryDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_scoped.kt
   FUN name:dsl_scoped visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Repository modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/factory_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/factory_basic.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__myServiceDsl_factory.kt
   FUN name:dsl_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/hints_package_no_annotations.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/hints_package_no_annotations.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/main__repoDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repo
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_factory.kt
   FUN name:dsl_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Repo modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/scoped_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/scoped_basic.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/main__repositoryDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__scopedServiceDsl_scoped.kt
   FUN name:dsl_scoped visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ScopedService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Repository modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_basic.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__myServiceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_with_default_value.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_with_default_value.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__serviceWithDefaultDsl_single.k
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ServiceWithDefault
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ServiceWithDefault modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_with_dependency.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_with_dependency.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/main__repositoryDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Repository modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_with_lazy.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_with_lazy.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/main__consumerDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Consumer
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__heavyDepDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.HeavyDep
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Consumer modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/dsl/single_with_nullable.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_with_nullable.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:OptionalDependency modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/modules/component_scan_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/modules/component_scan_basic.fir.ir.txt
@@ -2,12 +2,12 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testpkg_ScanModule.kt
   FUN name:componentscan_testpkg_ScanModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:testpkg.ServiceB
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testpkg_ScanModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:testpkg.ServiceA
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:testpkg fileName:/test.kt
   CLASS CLASS name:ScanModule modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/modules/component_scan_basic.fir.txt
+++ b/koin-compiler-plugin/testData/box/modules/component_scan_basic.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class ScanModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class ScanModule : R|kotlin/Any| {
         public constructor(): R|testpkg/ScanModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/modules/module_extension.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/modules/module_extension.fir.ir.txt
@@ -24,7 +24,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_appModule.kt
   FUN name:componentscan_appModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.AppService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/modules/module_with_functions.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/modules/module_with_functions.fir.ir.txt
@@ -235,14 +235,14 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/functionModuleM
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_functionModule__provideRepository visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_functionModule__provideService visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/params/injected_param.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/params/injected_param.fir.ir.txt
@@ -2,14 +2,14 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ServiceWithParam
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__injectedparams_ServiceWithParam.kt
   FUN name:injectedparams_ServiceWithParam visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:id index:0 type:kotlin.Int
     VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ServiceWithParam modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/params/lazy_injection.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/params/lazy_injection.fir.ir.txt
@@ -2,12 +2,12 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Consumer
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.HeavyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Consumer modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/params/property_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/params/property_basic.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Config
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Config modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/params/property_basic.fir.txt
+++ b/koin-compiler-plugin/testData/box/params/property_basic.fir.txt
@@ -6,7 +6,7 @@ FILE: test.kt
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class Config : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Property|(value = String(server.host)) host: R|kotlin/String|, @R|org/koin/core/annotation/Property|(value = String(server.port)) port: R|kotlin/String|): R|Config| {
+        public constructor(@R|org/koin/core/annotation/Property|(value = String(server.host) [evaluated = String(server.host)]) host: R|kotlin/String|, @R|org/koin/core/annotation/Property|(value = String(server.port) [evaluated = String(server.port)]) port: R|kotlin/String|): R|Config| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/qualifiers/custom_qualifier_type.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/custom_qualifier_type.fir.ir.txt
@@ -2,25 +2,25 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.UrlConsumer
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_testModule_single__q_AuthUrl visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:kotlin.String
     VALUE_PARAMETER kind:Regular name:qualifierType index:1 type:<root>.AuthUrl
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_testModule_single__q_BaseUrl visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:kotlin.String
     VALUE_PARAMETER kind:Regular name:qualifierType index:1 type:<root>.BaseUrl
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_testModule_single__roster visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:q_AuthUrl index:0 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:q_BaseUrl index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS ANNOTATION_CLASS name:AuthUrl modality:OPEN visibility:public superTypes:[kotlin.Annotation]
@@ -92,6 +92,8 @@ FILE fqName:<root> fileName:/test.kt
       Singleton(binds = <null>, createdAtStart = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.UrlConsumer
     PROPERTY name:base visibility:public modality:FINAL [val]
+      annotations:
+        BaseUrl
       FIELD PROPERTY_BACKING_FIELD name:base type:kotlin.String visibility:private [final]
         EXPRESSION_BODY
           GET_VAR 'base: kotlin.String declared in <root>.UrlConsumer.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
@@ -103,6 +105,8 @@ FILE fqName:<root> fileName:/test.kt
             GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:base type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
               receiver: GET_VAR '<this>: <root>.UrlConsumer declared in <root>.UrlConsumer.<get-base>' type=<root>.UrlConsumer origin=null
     PROPERTY name:auth visibility:public modality:FINAL [val]
+      annotations:
+        AuthUrl
       FIELD PROPERTY_BACKING_FIELD name:auth type:kotlin.String visibility:private [final]
         EXPRESSION_BODY
           GET_VAR 'auth: kotlin.String declared in <root>.UrlConsumer.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
@@ -283,7 +287,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/authUrlDefiniti
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:qualifier visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.AuthUrl
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -291,7 +295,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/baseUrlDefiniti
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:qualifier visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.BaseUrl
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/qualifiers/custom_qualifier_type.fir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/custom_qualifier_type.fir.txt
@@ -28,10 +28,10 @@ FILE: test.kt
             super<R|kotlin/Any|>()
         }
 
-        public final val base: R|kotlin/String| = R|<local>/base|
+        @R|BaseUrl|() public final val base: R|kotlin/String| = R|<local>/base|
             public get(): R|kotlin/String|
 
-        public final val auth: R|kotlin/String| = R|<local>/auth|
+        @R|AuthUrl|() public final val auth: R|kotlin/String| = R|<local>/auth|
             public get(): R|kotlin/String|
 
     }

--- a/koin-compiler-plugin/testData/box/qualifiers/named_on_class.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/named_on_class.fir.ir.txt
@@ -4,14 +4,14 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:qualifier_prod index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.TestService
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:qualifier_test index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ProdService modality:FINAL visibility:public superTypes:[<root>.Service]

--- a/koin-compiler-plugin/testData/box/qualifiers/named_on_class.fir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/named_on_class.fir.txt
@@ -7,13 +7,13 @@ FILE: test.kt
     }
     public abstract interface Service : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(prod)) public final class ProdService : R|Service| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(prod) [evaluated = String(prod)]) public final class ProdService : R|Service| {
         public constructor(): R|ProdService| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(test)) public final class TestService : R|Service| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(test) [evaluated = String(test)]) public final class TestService : R|Service| {
         public constructor(): R|TestService| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/qualifiers/named_on_parameter.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/named_on_parameter.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Consumer
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.SpecialDependency
     VALUE_PARAMETER kind:Regular name:qualifier_special index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Consumer modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/qualifiers/named_on_parameter.fir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/named_on_parameter.fir.txt
@@ -5,14 +5,14 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(special)) public final class SpecialDependency : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(special) [evaluated = String(special)]) public final class SpecialDependency : R|kotlin/Any| {
         public constructor(): R|SpecialDependency| {
             super<R|kotlin/Any|>()
         }
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class Consumer : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(special)) dep: R|SpecialDependency|): R|Consumer| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(special) [evaluated = String(special)]) dep: R|SpecialDependency|): R|Consumer| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/qualifiers/qualifier_type.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/qualifier_type.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Consumer
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.QualifiedService
     VALUE_PARAMETER kind:Regular name:qualifierType index:1 type:<root>.ProdQualifier
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Consumer modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -29,7 +29,7 @@ FILE fqName:<root> fileName:/test.kt
     CONSTRUCTOR visibility:public returnType:<root>.Consumer [primary]
       VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.QualifiedService
         annotations:
-          Qualifier(value = CLASS_REFERENCE 'CLASS INTERFACE name:ProdQualifier modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.ProdQualifier>, name = <null>)
+          Qualifier(value = ProdQualifier::class, name = <null>)
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Consumer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
@@ -49,7 +49,7 @@ FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:QualifiedService modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
       Singleton(binds = <null>, createdAtStart = <null>)
-      Qualifier(value = CLASS_REFERENCE 'CLASS INTERFACE name:ProdQualifier modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.ProdQualifier>, name = <null>)
+      Qualifier(value = ProdQualifier::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.QualifiedService
     CONSTRUCTOR visibility:public returnType:<root>.QualifiedService [primary]
       BLOCK_BODY

--- a/koin-compiler-plugin/testData/box/qualifiers/qualifier_type.fir.txt
+++ b/koin-compiler-plugin/testData/box/qualifiers/qualifier_type.fir.txt
@@ -7,14 +7,14 @@ FILE: test.kt
     }
     public abstract interface ProdQualifier : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|ProdQualifier|)) public final class QualifiedService : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|ProdQualifier|) [evaluated = <getClass>(Q|ProdQualifier|)]) public final class QualifiedService : R|kotlin/Any| {
         public constructor(): R|QualifiedService| {
             super<R|kotlin/Any|>()
         }
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class Consumer : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|ProdQualifier|)) service: R|QualifiedService|): R|Consumer| {
+        public constructor(@R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|ProdQualifier|) [evaluated = <getClass>(Q|ProdQualifier|)]) service: R|QualifiedService|): R|Consumer| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/safety/callsite_hint_module_prefix.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/callsite_hint_module_prefix.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__myService_callsite.kt
   FUN name:callsite visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:required index:0 type:<root>.MyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:LibraryConsumer modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/complete_graph.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/complete_graph.fir.ir.txt
@@ -2,17 +2,17 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Presenter
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Presenter modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/configuration_group.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/configuration_group.fir.ir.txt
@@ -93,13 +93,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_coreModule.kt
   FUN name:componentscan_coreModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:core.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_serviceModule.kt
   FUN name:componentscan_serviceModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:service.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:service fileName:/service/Service.kt
   CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -200,7 +200,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/coreModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.CoreModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -208,7 +208,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/serviceModuleMo
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.ServiceModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/configuration_group.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/configuration_group.fir.txt
@@ -20,13 +20,13 @@ FILE: Service.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core))) @R|org/koin/core/annotation/Configuration|() public final class CoreModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core)) [evaluated = vararg(String(core))]) @R|org/koin/core/annotation/Configuration|() public final class CoreModule : R|kotlin/Any| {
         public constructor(): R|CoreModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) @R|org/koin/core/annotation/Configuration|() public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) @R|org/koin/core/annotation/Configuration|() public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/default_value_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/default_value_ok.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/dsl_create_function.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_create_function.fir.ir.txt
@@ -4,14 +4,14 @@ FILE fqName:org.koin.plugin.hints fileName:/main__configDsl_single.kt
     VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:providerOnly index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:appModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/dsl_injected_param_d006.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_injected_param_d006.fir.ir.txt
@@ -3,13 +3,13 @@ FILE fqName:org.koin.plugin.hints fileName:/main__greeterDsl_factory.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Greeter
     VALUE_PARAMETER kind:Regular name:module_myModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__injectedparams_Greeter.kt
   FUN name:injectedparams_Greeter visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:myModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/dsl_module_includes.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_module_includes.fir.ir.txt
@@ -3,14 +3,14 @@ FILE fqName:org.koin.plugin.hints fileName:/main__repositoryDsl_single.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     VALUE_PARAMETER kind:Regular name:module_coreModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:coreModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/dsl_nested_includes.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_nested_includes.fir.ir.txt
@@ -3,7 +3,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__databaseDsl_single.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Database
     VALUE_PARAMETER kind:Regular name:module_dbModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:dbModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/dsl_transitive_includes.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/dsl_transitive_includes.fir.ir.txt
@@ -3,21 +3,21 @@ FILE fqName:org.koin.plugin.hints fileName:/main__databaseDsl_single.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Database
     VALUE_PARAMETER kind:Regular name:module_dbModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__repositoryDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Repository
     VALUE_PARAMETER kind:Regular name:module_dataModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_single.kt
   FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:module_appModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:dbModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/generic_dsl_type_no_crash.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/generic_dsl_type_no_crash.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__navigator_callsite.kt
   FUN name:callsite visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:required index:0 type:<root>.Navigator<kotlin.Any?>
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AppKey modality:FINAL visibility:public superTypes:[<root>.Key]

--- a/koin-compiler-plugin/testData/box/safety/injected_param_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/injected_param_ok.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Greeter
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/main__injectedparams_Greeter.kt
   FUN name:injectedparams_Greeter visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/injected_param_unit_qualifier_collision.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/injected_param_unit_qualifier_collision.fir.ir.txt
@@ -42,19 +42,19 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_launchersModule.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:qualifier_initNoParam index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_launchersModule_single__q_initWithParam visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:qualifier_initWithParam index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_launchersModule_single__roster visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:q_initNoParam index:0 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:q_initWithParam index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:LaunchersModule modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/injected_param_unit_qualifier_collision.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/injected_param_unit_qualifier_collision.fir.txt
@@ -5,10 +5,10 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Named|(value = String(initWithParam)) @R|org/koin/core/annotation/Singleton|() public final fun initWithParam(@R|org/koin/core/annotation/InjectedParam|() tag: R|kotlin/String|): R|kotlin/Unit| {
+    @R|org/koin/core/annotation/Named|(value = String(initWithParam) [evaluated = String(initWithParam)]) @R|org/koin/core/annotation/Singleton|() public final fun initWithParam(@R|org/koin/core/annotation/InjectedParam|() tag: R|kotlin/String|): R|kotlin/Unit| {
         R|kotlin/check|(==(R|<local>/tag|, String(x)))
     }
-    @R|org/koin/core/annotation/Named|(value = String(initNoParam)) @R|org/koin/core/annotation/Singleton|() public final fun initNoParam(): R|kotlin/Unit| {
+    @R|org/koin/core/annotation/Named|(value = String(initNoParam) [evaluated = String(initNoParam)]) @R|org/koin/core/annotation/Singleton|() public final fun initNoParam(): R|kotlin/Unit| {
     }
     public final fun box(): R|kotlin/String| {
         lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {

--- a/koin-compiler-plugin/testData/box/safety/lazy_valid.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/lazy_valid.fir.ir.txt
@@ -2,12 +2,12 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Consumer
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.HeavyService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Consumer modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/list_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/list_ok.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.PluginManager
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:PluginManager modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/module_includes_chain.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/module_includes_chain.fir.ir.txt
@@ -88,7 +88,7 @@ FILE fqName:<root> fileName:/infraModuleModule.kt
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      Module(includes = [CLASS_REFERENCE 'CLASS CLASS name:DataModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.DataModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+      Module(includes = [DataModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AppModule
     CONSTRUCTOR visibility:public returnType:<root>.AppModule [primary]
       BLOCK_BODY
@@ -149,7 +149,7 @@ FILE fqName:<root> fileName:/test.kt
         public open fun toString (): kotlin.String declared in kotlin.Any
   CLASS CLASS name:DataModule modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      Module(includes = [CLASS_REFERENCE 'CLASS CLASS name:InfraModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.InfraModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+      Module(includes = [InfraModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.DataModule
     CONSTRUCTOR visibility:public returnType:<root>.DataModule [primary]
       BLOCK_BODY
@@ -290,7 +290,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/appModuleModule
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_appModule__provideService visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.AppService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -298,7 +298,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/dataModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_dataModule__provideRepo visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -306,7 +306,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/infraModuleModu
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_infraModule__provideDb visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Database
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/module_includes_chain.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/module_includes_chain.fir.txt
@@ -33,7 +33,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|InfraModule|))) public final class DataModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|InfraModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|InfraModule|))]) public final class DataModule : R|kotlin/Any| {
         public constructor(): R|DataModule| {
             super<R|kotlin/Any|>()
         }
@@ -43,7 +43,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|DataModule|))) public final class AppModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|DataModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|DataModule|))]) public final class AppModule : R|kotlin/Any| {
         public constructor(): R|AppModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/module_includes_visible.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/module_includes_visible.fir.ir.txt
@@ -56,7 +56,7 @@ FILE fqName:<root> fileName:/infraModuleModule.kt
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      Module(includes = [CLASS_REFERENCE 'CLASS CLASS name:InfraModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.InfraModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+      Module(includes = [InfraModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AppModule
     CONSTRUCTOR visibility:public returnType:<root>.AppModule [primary]
       BLOCK_BODY
@@ -196,7 +196,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/appModuleModule
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_appModule__provideService visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.AppService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -204,7 +204,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/infraModuleModu
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_infraModule__provideDatabase visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Database
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/module_includes_visible.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/module_includes_visible.fir.txt
@@ -15,7 +15,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|InfraModule|))) public final class AppModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|(includes = <collectionLiteralCall>(<getClass>(Q|InfraModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|InfraModule|))]) public final class AppModule : R|kotlin/Any| {
         public constructor(): R|AppModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/nullable_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/nullable_ok.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:MissingDep modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/property_value_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/property_value_ok.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ApiClient
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:defaultApiTimeout visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/property_value_ok.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/property_value_ok.fir.txt
@@ -1,8 +1,8 @@
 FILE: test.kt
-    field:@R|org/koin/core/annotation/PropertyValue|(value = String(api.timeout)) public final val defaultApiTimeout: R|kotlin/Int| = Int(30)
+    field:@R|org/koin/core/annotation/PropertyValue|(value = String(api.timeout) [evaluated = String(api.timeout)]) public final val defaultApiTimeout: R|kotlin/Int| = Int(30)
         public get(): R|kotlin/Int|
     @R|org/koin/core/annotation/Factory|() public final class ApiClient : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Property|(value = String(api.timeout)) timeout: R|kotlin/Int|): R|ApiClient| {
+        public constructor(@R|org/koin/core/annotation/Property|(value = String(api.timeout) [evaluated = String(api.timeout)]) timeout: R|kotlin/Int|): R|ApiClient| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/safety/provided_param_dsl_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/provided_param_dsl_ok.fir.ir.txt
@@ -3,7 +3,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__serviceDsl_single.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     VALUE_PARAMETER kind:Regular name:module_testModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:testModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/provided_param_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/provided_param_ok.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ExternalContext modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/provided_type_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/provided_type_ok.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ExternalContext modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/qualified_function_cross_module.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualified_function_cross_module.fir.ir.txt
@@ -133,26 +133,26 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_consumerModule.kt
   FUN name:componentscan_consumerModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:consumer.UrlClient
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_serviceModule.kt
   FUN name:componentscanfunc_serviceModule_single__q_authUrl visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:service.Url
     VALUE_PARAMETER kind:Regular name:qualifier_authUrl index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_serviceModule_single__q_baseUrl visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:service.Url
     VALUE_PARAMETER kind:Regular name:qualifier_baseUrl index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_serviceModule_single__roster visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:q_authUrl index:0 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:q_baseUrl index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:service fileName:/service/Services.kt
   CLASS INTERFACE name:Url modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
@@ -354,7 +354,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/consumerModuleM
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.ConsumerModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -362,7 +362,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/serviceModuleMo
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.ServiceModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/qualified_function_cross_module.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualified_function_cross_module.fir.txt
@@ -6,7 +6,7 @@ FILE: Services.kt
             public get(): R|kotlin/String|
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(baseUrl)) public final fun provideBaseUrl(): R|service/Url| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(baseUrl) [evaluated = String(baseUrl)]) public final fun provideBaseUrl(): R|service/Url| {
         ^provideBaseUrl object : R|service/Url| {
             private constructor(): R|service/<anonymous>| {
                 super<R|kotlin/Any|>()
@@ -18,7 +18,7 @@ FILE: Services.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(authUrl)) public final fun provideAuthUrl(): R|service/Url| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(authUrl) [evaluated = String(authUrl)]) public final fun provideAuthUrl(): R|service/Url| {
         ^provideAuthUrl object : R|service/Url| {
             private constructor(): R|service/<anonymous>| {
                 super<R|kotlin/Any|>()
@@ -34,7 +34,7 @@ FILE: UrlClient.kt
     package consumer
 
     @R|org/koin/core/annotation/Singleton|() public final class UrlClient : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(baseUrl)) base: R|service/Url|, @R|org/koin/core/annotation/Named|(value = String(authUrl)) auth: R|service/Url|): R|consumer/UrlClient| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(baseUrl) [evaluated = String(baseUrl)]) base: R|service/Url|, @R|org/koin/core/annotation/Named|(value = String(authUrl) [evaluated = String(authUrl)]) auth: R|service/Url|): R|consumer/UrlClient| {
             super<R|kotlin/Any|>()
         }
 
@@ -46,13 +46,13 @@ FILE: UrlClient.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) @R|org/koin/core/annotation/Configuration|() public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) @R|org/koin/core/annotation/Configuration|() public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(consumer))) @R|org/koin/core/annotation/Configuration|() public final class ConsumerModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(consumer)) [evaluated = vararg(String(consumer))]) @R|org/koin/core/annotation/Configuration|() public final class ConsumerModule : R|kotlin/Any| {
         public constructor(): R|ConsumerModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/qualifier_cross_module.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_cross_module.fir.ir.txt
@@ -153,20 +153,20 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_dataModule.kt
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.Cache
     VALUE_PARAMETER kind:Regular name:qualifier_local index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_dataModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:data.RemoteCache
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.Cache
     VALUE_PARAMETER kind:Regular name:qualifier_remote index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_uiModule.kt
   FUN name:componentscan_uiModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:ui.CacheManager
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
@@ -304,7 +304,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/dataModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.DataModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -312,7 +312,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/uiModuleModule.
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.UiModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/qualifier_cross_module.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_cross_module.fir.txt
@@ -3,13 +3,13 @@ FILE: CacheImpl.kt
 
     public abstract interface Cache : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(local)) public final class LocalCache : R|data/Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(local) [evaluated = String(local)]) public final class LocalCache : R|data/Cache| {
         public constructor(): R|data/LocalCache| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(remote)) public final class RemoteCache : R|data/Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(remote) [evaluated = String(remote)]) public final class RemoteCache : R|data/Cache| {
         public constructor(): R|data/RemoteCache| {
             super<R|kotlin/Any|>()
         }
@@ -19,7 +19,7 @@ FILE: CacheManager.kt
     package ui
 
     @R|org/koin/core/annotation/Singleton|() public final class CacheManager : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(local)) local: R|data/Cache|, @R|org/koin/core/annotation/Named|(value = String(remote)) remote: R|data/Cache|): R|ui/CacheManager| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(local) [evaluated = String(local)]) local: R|data/Cache|, @R|org/koin/core/annotation/Named|(value = String(remote) [evaluated = String(remote)]) remote: R|data/Cache|): R|ui/CacheManager| {
             super<R|kotlin/Any|>()
         }
 
@@ -31,13 +31,13 @@ FILE: CacheManager.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data))) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data)) [evaluated = vararg(String(data))]) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
         public constructor(): R|DataModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui))) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui)) [evaluated = vararg(String(ui))]) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
         public constructor(): R|UiModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:data fileName:/data/CacheImpl.kt
   CLASS CLASS name:LocalCache modality:FINAL visibility:public superTypes:[data.Cache]
     annotations:
       Singleton(binds = <null>, createdAtStart = <null>)
-      Qualifier(value = CLASS_REFERENCE 'CLASS CLASS name:LocalQualifier modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<data.LocalQualifier>, name = <null>)
+      Qualifier(value = LocalQualifier::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:data.LocalCache
     CONSTRUCTOR visibility:public returnType:data.LocalCache [primary]
       BLOCK_BODY
@@ -43,7 +43,7 @@ FILE fqName:data fileName:/data/CacheImpl.kt
   CLASS CLASS name:RemoteCache modality:FINAL visibility:public superTypes:[data.Cache]
     annotations:
       Singleton(binds = <null>, createdAtStart = <null>)
-      Qualifier(value = CLASS_REFERENCE 'CLASS CLASS name:RemoteQualifier modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<data.RemoteQualifier>, name = <null>)
+      Qualifier(value = RemoteQualifier::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:data.RemoteCache
     CONSTRUCTOR visibility:public returnType:data.RemoteCache [primary]
       BLOCK_BODY
@@ -193,20 +193,20 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_dataModule.kt
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.Cache
     VALUE_PARAMETER kind:Regular name:qualifierType index:2 type:data.LocalQualifier
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_dataModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:data.RemoteCache
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.Cache
     VALUE_PARAMETER kind:Regular name:qualifierType index:2 type:data.RemoteQualifier
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_uiModule.kt
   FUN name:componentscan_uiModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:ui.CacheManager
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
@@ -286,10 +286,10 @@ FILE fqName:ui fileName:/ui/CacheManager.kt
     CONSTRUCTOR visibility:public returnType:ui.CacheManager [primary]
       VALUE_PARAMETER kind:Regular name:local index:0 type:data.Cache
         annotations:
-          Qualifier(value = CLASS_REFERENCE 'CLASS CLASS name:LocalQualifier modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<data.LocalQualifier>, name = <null>)
+          Qualifier(value = LocalQualifier::class, name = <null>)
       VALUE_PARAMETER kind:Regular name:remote index:1 type:data.Cache
         annotations:
-          Qualifier(value = CLASS_REFERENCE 'CLASS CLASS name:RemoteQualifier modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<data.RemoteQualifier>, name = <null>)
+          Qualifier(value = RemoteQualifier::class, name = <null>)
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:CacheManager modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
@@ -346,7 +346,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/dataModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.DataModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -354,7 +354,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/uiModuleModule.
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.UiModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_cross_module_type.fir.txt
@@ -15,13 +15,13 @@ FILE: CacheImpl.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/LocalQualifier|)) public final class LocalCache : R|data/Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/LocalQualifier|) [evaluated = <getClass>(Q|data/LocalQualifier|)]) public final class LocalCache : R|data/Cache| {
         public constructor(): R|data/LocalCache| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/RemoteQualifier|)) public final class RemoteCache : R|data/Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/RemoteQualifier|) [evaluated = <getClass>(Q|data/RemoteQualifier|)]) public final class RemoteCache : R|data/Cache| {
         public constructor(): R|data/RemoteCache| {
             super<R|kotlin/Any|>()
         }
@@ -31,7 +31,7 @@ FILE: CacheManager.kt
     package ui
 
     @R|org/koin/core/annotation/Singleton|() public final class CacheManager : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/LocalQualifier|)) local: R|data/Cache|, @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/RemoteQualifier|)) remote: R|data/Cache|): R|ui/CacheManager| {
+        public constructor(@R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/LocalQualifier|) [evaluated = <getClass>(Q|data/LocalQualifier|)]) local: R|data/Cache|, @R|org/koin/core/annotation/Qualifier|(value = <getClass>(Q|data/RemoteQualifier|) [evaluated = <getClass>(Q|data/RemoteQualifier|)]) remote: R|data/Cache|): R|ui/CacheManager| {
             super<R|kotlin/Any|>()
         }
 
@@ -43,13 +43,13 @@ FILE: CacheManager.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data))) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data)) [evaluated = vararg(String(data))]) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
         public constructor(): R|DataModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui))) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui)) [evaluated = vararg(String(ui))]) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
         public constructor(): R|UiModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.fir.ir.txt
@@ -153,20 +153,20 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_dataModule.kt
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.DataSource
     VALUE_PARAMETER kind:Regular name:qualifier_com$2eexample$2elocal index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_dataModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:data.RemoteDataSource
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:data.DataSource
     VALUE_PARAMETER kind:Regular name:qualifier_com$2eexample$2eremote index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_uiModule.kt
   FUN name:componentscan_uiModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:ui.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
@@ -304,7 +304,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/dataModuleModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.DataModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -312,7 +312,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/uiModuleModule.
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.UiModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_dotted_name.fir.txt
@@ -3,13 +3,13 @@ FILE: Services.kt
 
     public abstract interface DataSource : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(com.example.local)) public final class LocalDataSource : R|data/DataSource| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(com.example.local) [evaluated = String(com.example.local)]) public final class LocalDataSource : R|data/DataSource| {
         public constructor(): R|data/LocalDataSource| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(com.example.remote)) public final class RemoteDataSource : R|data/DataSource| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(com.example.remote) [evaluated = String(com.example.remote)]) public final class RemoteDataSource : R|data/DataSource| {
         public constructor(): R|data/RemoteDataSource| {
             super<R|kotlin/Any|>()
         }
@@ -19,7 +19,7 @@ FILE: Repository.kt
     package ui
 
     @R|org/koin/core/annotation/Singleton|() public final class Repository : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(com.example.local)) local: R|data/DataSource|, @R|org/koin/core/annotation/Named|(value = String(com.example.remote)) remote: R|data/DataSource|): R|ui/Repository| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(com.example.local) [evaluated = String(com.example.local)]) local: R|data/DataSource|, @R|org/koin/core/annotation/Named|(value = String(com.example.remote) [evaluated = String(com.example.remote)]) remote: R|data/DataSource|): R|ui/Repository| {
             super<R|kotlin/Any|>()
         }
 
@@ -31,13 +31,13 @@ FILE: Repository.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data))) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(data)) [evaluated = vararg(String(data))]) @R|org/koin/core/annotation/Configuration|() public final class DataModule : R|kotlin/Any| {
         public constructor(): R|DataModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui))) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(ui)) [evaluated = vararg(String(ui))]) @R|org/koin/core/annotation/Configuration|() public final class UiModule : R|kotlin/Any| {
         public constructor(): R|UiModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/qualifier_match.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_match.fir.ir.txt
@@ -2,21 +2,21 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.CacheManager
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.LocalCache
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.Cache
     VALUE_PARAMETER kind:Regular name:qualifier_local index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.RemoteCache
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.Cache
     VALUE_PARAMETER kind:Regular name:qualifier_remote index:2 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:CacheManager modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/qualifier_match.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/qualifier_match.fir.txt
@@ -7,20 +7,20 @@ FILE: test.kt
     }
     public abstract interface Cache : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(local)) public final class LocalCache : R|Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(local) [evaluated = String(local)]) public final class LocalCache : R|Cache| {
         public constructor(): R|LocalCache| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(remote)) public final class RemoteCache : R|Cache| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(remote) [evaluated = String(remote)]) public final class RemoteCache : R|Cache| {
         public constructor(): R|RemoteCache| {
             super<R|kotlin/Any|>()
         }
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class CacheManager : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(local)) local: R|Cache|, @R|org/koin/core/annotation/Named|(value = String(remote)) remote: R|Cache|): R|CacheManager| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(local) [evaluated = String(local)]) local: R|Cache|, @R|org/koin/core/annotation/Named|(value = String(remote) [evaluated = String(remote)]) remote: R|Cache|): R|CacheManager| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/safety/scope_id_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scope_id_ok.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ProfileService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ProfileService modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/scope_id_ok.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scope_id_ok.fir.txt
@@ -9,7 +9,7 @@ FILE: test.kt
 
     }
     @R|org/koin/core/annotation/Factory|() public final class ProfileService : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/ScopeId|(name = String(user_session)) session: R|UserSession|): R|ProfileService| {
+        public constructor(@R|org/koin/core/annotation/ScopeId|(name = String(user_session) [evaluated = String(user_session)]) session: R|UserSession|): R|ProfileService| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/safety/scope_param_dsl_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scope_param_dsl_ok.fir.ir.txt
@@ -3,7 +3,7 @@ FILE fqName:org.koin.plugin.hints fileName:/main__scopeAwareRepositoryDsl_single
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ScopeAwareRepository
     VALUE_PARAMETER kind:Regular name:module_testModule index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   PROPERTY name:testModule visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/safety/scope_param_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scope_param_ok.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ScopeAwareService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ScopeAwareService modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/scoped_visibility.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scoped_visibility.fir.ir.txt
@@ -3,12 +3,12 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.SessionData
     VALUE_PARAMETER kind:Regular name:scope index:1 type:<root>.SessionScope
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.AuthService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AuthService modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -35,7 +35,7 @@ FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:SessionData modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
       Scoped(binds = <null>)
-      Scope(value = CLASS_REFERENCE 'CLASS CLASS name:SessionScope modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.SessionScope>, name = <null>)
+      Scope(value = SessionScope::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.SessionData
     PROPERTY name:auth visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:auth type:<root>.AuthService visibility:private [final]

--- a/koin-compiler-plugin/testData/box/safety/scoped_visibility.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/scoped_visibility.fir.txt
@@ -17,7 +17,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|SessionScope|)) public final class SessionData : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|SessionScope|) [evaluated = <getClass>(Q|SessionScope|)]) public final class SessionData : R|kotlin/Any| {
         public constructor(auth: R|AuthService|): R|SessionData| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/startkoin_full_graph.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/startkoin_full_graph.fir.ir.txt
@@ -1,7 +1,7 @@
 FILE fqName:<root> fileName:/app.kt
   CLASS OBJECT name:MyApp modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      KoinApplication(configurations = <null>, modules = [CLASS_REFERENCE 'CLASS CLASS name:CoreModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.CoreModule>, CLASS_REFERENCE 'CLASS CLASS name:ServiceModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.ServiceModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>)
+      KoinApplication(configurations = <null>, modules = [CoreModule::class, ServiceModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MyApp
     CONSTRUCTOR visibility:private returnType:<root>.MyApp [primary]
       BLOCK_BODY
@@ -113,13 +113,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_coreModule.kt
   FUN name:componentscan_coreModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:core.Repository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_serviceModule.kt
   FUN name:componentscan_serviceModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:service.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:service fileName:/service/Service.kt
   CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/safety/startkoin_full_graph.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/startkoin_full_graph.fir.txt
@@ -20,20 +20,20 @@ FILE: Service.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core))) public final class CoreModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core)) [evaluated = vararg(String(core))]) public final class CoreModule : R|kotlin/Any| {
         public constructor(): R|CoreModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }
 
     }
 FILE: app.kt
-    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|CoreModule|), <getClass>(Q|ServiceModule|))) public final object MyApp : R|kotlin/Any| {
+    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|CoreModule|), <getClass>(Q|ServiceModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|CoreModule|), <getClass>(Q|ServiceModule|))]) public final object MyApp : R|kotlin/Any| {
         private constructor(): R|MyApp| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/safety/toplevel_function_ok.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/toplevel_function_ok.fir.ir.txt
@@ -2,12 +2,12 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.DataSource
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:DatabaseDataSource modality:FINAL visibility:public superTypes:[<root>.DataSource]

--- a/koin-compiler-plugin/testData/box/scopes/scope_class.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/scopes/scope_class.fir.ir.txt
@@ -3,7 +3,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ScopedService
     VALUE_PARAMETER kind:Regular name:scope index:1 type:<root>.MyScope
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:MyScope modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -28,7 +28,7 @@ FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ScopedService modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
       Scoped(binds = <null>)
-      Scope(value = CLASS_REFERENCE 'CLASS CLASS name:MyScope modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.MyScope>, name = <null>)
+      Scope(value = MyScope::class, name = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.ScopedService
     CONSTRUCTOR visibility:public returnType:<root>.ScopedService [primary]
       BLOCK_BODY

--- a/koin-compiler-plugin/testData/box/scopes/scope_class.fir.txt
+++ b/koin-compiler-plugin/testData/box/scopes/scope_class.fir.txt
@@ -11,7 +11,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|MyScope|)) public final class ScopedService : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|MyScope|) [evaluated = <getClass>(Q|MyScope|)]) public final class ScopedService : R|kotlin/Any| {
         public constructor(): R|ScopedService| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/scopes/scope_id_param_name.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/scopes/scope_id_param_name.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Lex
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_scoped visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Tnt
     VALUE_PARAMETER kind:Regular name:scope index:1 type:<root>.MyType
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:Lex modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -70,7 +70,7 @@ FILE fqName:<root> fileName:/test.kt
         public open fun toString (): kotlin.String declared in kotlin.Any
   CLASS CLASS name:Tnt modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
-      Scope(value = CLASS_REFERENCE 'CLASS INTERFACE name:MyType modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.MyType>, name = <null>)
+      Scope(value = MyType::class, name = <null>)
       Scoped(binds = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Tnt
     PROPERTY name:signature visibility:public modality:FINAL [val]

--- a/koin-compiler-plugin/testData/box/scopes/scope_id_param_name.fir.txt
+++ b/koin-compiler-plugin/testData/box/scopes/scope_id_param_name.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     public abstract interface MyType : R|kotlin/Any| {
     }
-    @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|MyType|)) @R|org/koin/core/annotation/Scoped|() public final class Tnt : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|MyType|) [evaluated = <getClass>(Q|MyType|)]) @R|org/koin/core/annotation/Scoped|() public final class Tnt : R|kotlin/Any| {
         public constructor(): R|Tnt| {
             super<R|kotlin/Any|>()
         }
@@ -11,7 +11,7 @@ FILE: test.kt
 
     }
     @R|org/koin/core/annotation/Factory|() public final class Lex : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/ScopeId|(name = String(a)) t: R|Tnt|): R|Lex| {
+        public constructor(@R|org/koin/core/annotation/ScopeId|(name = String(a) [evaluated = String(a)]) t: R|Tnt|): R|Lex| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/box/scopes/scope_name.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/scopes/scope_name.fir.ir.txt
@@ -2,13 +2,13 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
   FUN name:componentscan_testModule_scoped visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.SessionData
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_testModule_scoped visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.UserRepositoryImpl
     VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.UserRepository
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:SessionData modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -72,7 +72,7 @@ FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:UserRepositoryImpl modality:FINAL visibility:public superTypes:[<root>.UserRepository]
     annotations:
       Scope(value = <null>, name = "session")
-      Scoped(binds = [CLASS_REFERENCE 'CLASS INTERFACE name:UserRepository modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.UserRepository>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>)
+      Scoped(binds = [UserRepository::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.UserRepositoryImpl
     CONSTRUCTOR visibility:public returnType:<root>.UserRepositoryImpl [primary]
       BLOCK_BODY

--- a/koin-compiler-plugin/testData/box/scopes/scope_name.fir.txt
+++ b/koin-compiler-plugin/testData/box/scopes/scope_name.fir.txt
@@ -9,7 +9,7 @@ FILE: test.kt
         public abstract fun id(): R|kotlin/String|
 
     }
-    @R|org/koin/core/annotation/Scope|(name = String(session)) @R|org/koin/core/annotation/Scoped|(binds = <collectionLiteralCall>(<getClass>(Q|UserRepository|))) public final class UserRepositoryImpl : R|UserRepository| {
+    @R|org/koin/core/annotation/Scope|(name = String(session) [evaluated = String(session)]) @R|org/koin/core/annotation/Scoped|(binds = <collectionLiteralCall>(<getClass>(Q|UserRepository|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|UserRepository|))]) public final class UserRepositoryImpl : R|UserRepository| {
         public constructor(): R|UserRepositoryImpl| {
             super<R|kotlin/Any|>()
         }
@@ -19,7 +19,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Scope|(name = String(session)) @R|org/koin/core/annotation/Scoped|() public final class SessionData : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scope|(name = String(session) [evaluated = String(session)]) @R|org/koin/core/annotation/Scoped|() public final class SessionData : R|kotlin/Any| {
         public constructor(token: R|kotlin/String| = String(session-token)): R|SessionData| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/box/startkoin/configuration_discovery.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/startkoin/configuration_discovery.fir.ir.txt
@@ -24,7 +24,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_featureModule.kt
   FUN name:componentscan_featureModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.FeatureService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:FeatureModule modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -104,7 +104,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/featureModuleMo
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.FeatureModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/startkoin/explicit_modules_override_configuration.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/startkoin/explicit_modules_override_configuration.fir.ir.txt
@@ -173,7 +173,7 @@ FILE fqName:<root> fileName:/test.kt
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Feature
   CLASS INTERFACE name:MyApp modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
     annotations:
-      KoinApplication(configurations = <null>, modules = [CLASS_REFERENCE 'CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.AppModule>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>)
+      KoinApplication(configurations = <null>, modules = [AppModule::class] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MyApp
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
@@ -228,7 +228,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/appModuleModule
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_appModule__appFeature visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Feature
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
@@ -236,14 +236,14 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/coreConfigurati
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.CoreConfiguration
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_coreConfiguration__defaultFeature visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Feature
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/startkoin/explicit_modules_override_configuration.fir.txt
+++ b/koin-compiler-plugin/testData/box/startkoin/explicit_modules_override_configuration.fir.txt
@@ -43,7 +43,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|AppModule|))) public abstract interface MyApp : R|kotlin/Any| {
+    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|AppModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|AppModule|))]) public abstract interface MyApp : R|kotlin/Any| {
     }
     public final fun box(): R|kotlin/String| {
         lval koin: R|org/koin/core/Koin| = R|org/koin/plugin/module/dsl/startKoin|<R|MyApp|>(<L> = startKoin@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {

--- a/koin-compiler-plugin/testData/box/startkoin/koin_application.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/startkoin/koin_application.fir.ir.txt
@@ -24,7 +24,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_appModule.kt
   FUN name:componentscan_appModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.AppService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/startkoin/multiple_modules.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/startkoin/multiple_modules.fir.ir.txt
@@ -80,23 +80,23 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_moduleA.kt
   FUN name:componentscan_moduleA_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ServiceA
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_moduleA_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ServiceB
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:org.koin.plugin.hints fileName:/koin_hints_moduleB.kt
   FUN name:componentscan_moduleB_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ServiceA
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscan_moduleB_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.ServiceB
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:ModuleA modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/startkoin/startkoin_basic.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/startkoin/startkoin_basic.fir.ir.txt
@@ -24,7 +24,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_appModule.kt
   FUN name:componentscan_appModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.AppService
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]

--- a/koin-compiler-plugin/testData/box/toplevel/qualified_unit_singletons.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/toplevel/qualified_unit_singletons.fir.ir.txt
@@ -3,19 +3,19 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testpkg_AppModule.kt
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:qualifier_initFlagsAndLogging index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_testpkg_AppModule_single__q_initNotifier visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:qualifier_initNotifier index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
   FUN name:componentscanfunc_testpkg_AppModule_single__roster visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:q_initFlagsAndLogging index:0 type:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:q_initNotifier index:1 type:kotlin.Unit
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:testpkg fileName:/test.kt
   CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]
@@ -83,7 +83,7 @@ FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/testpkgAppModul
   FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:configuration_default visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:testpkg.AppModule
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"

--- a/koin-compiler-plugin/testData/box/toplevel/qualified_unit_singletons.fir.txt
+++ b/koin-compiler-plugin/testData/box/toplevel/qualified_unit_singletons.fir.txt
@@ -1,15 +1,15 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) @R|org/koin/core/annotation/Configuration|() public final class AppModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) @R|org/koin/core/annotation/Configuration|() public final class AppModule : R|kotlin/Any| {
         public constructor(): R|testpkg/AppModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Named|(value = String(initFlagsAndLogging)) @R|org/koin/core/annotation/Singleton|(createdAtStart = Boolean(true)) public final fun initFlagsAndLogging(): R|kotlin/Unit| {
+    @R|org/koin/core/annotation/Named|(value = String(initFlagsAndLogging) [evaluated = String(initFlagsAndLogging)]) @R|org/koin/core/annotation/Singleton|(createdAtStart = Boolean(true) [evaluated = Boolean(true)]) public final fun initFlagsAndLogging(): R|kotlin/Unit| {
     }
-    @R|org/koin/core/annotation/Named|(value = String(initNotifier)) @R|org/koin/core/annotation/Singleton|(createdAtStart = Boolean(true)) public final fun initNotifier(): R|kotlin/Unit| {
+    @R|org/koin/core/annotation/Named|(value = String(initNotifier) [evaluated = String(initNotifier)]) @R|org/koin/core/annotation/Singleton|(createdAtStart = Boolean(true) [evaluated = Boolean(true)]) public final fun initNotifier(): R|kotlin/Unit| {
     }
     public final fun box(): R|kotlin/String| {
         lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {

--- a/koin-compiler-plugin/testData/box/toplevel/singleton_function.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/toplevel/singleton_function.fir.ir.txt
@@ -2,7 +2,7 @@ FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testpkg_TestModule.kt
   FUN name:componentscanfunc_testpkg_TestModule_single visibility:public modality:FINAL returnType:kotlin.Unit
     VALUE_PARAMETER kind:Regular name:contributed index:0 type:testpkg.DataSource
     annotations:
-      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = DeprecationLevel.HIDDEN)
     BLOCK_BODY
 FILE fqName:testpkg fileName:/test.kt
   CLASS CLASS name:DatabaseDataSource modality:FINAL visibility:public superTypes:[testpkg.DataSource]

--- a/koin-compiler-plugin/testData/box/toplevel/singleton_function.fir.txt
+++ b/koin-compiler-plugin/testData/box/toplevel/singleton_function.fir.txt
@@ -12,7 +12,7 @@ FILE: test.kt
     @R|org/koin/core/annotation/Singleton|() public final fun provideDataSource(): R|testpkg/DataSource| {
         ^provideDataSource R|testpkg/DatabaseDataSource.DatabaseDataSource|()
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/call_site_param_arity_mismatch.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/call_site_param_arity_mismatch.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/call_site_param_missing_d006.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/call_site_param_missing_d006.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/call_site_param_no_injected_no_d006.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/call_site_param_no_injected_no_d006.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/call_site_param_nullable_ok.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/call_site_param_nullable_ok.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/call_site_param_ok.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/call_site_param_ok.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/call_site_param_type_mismatch.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/call_site_param_type_mismatch.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/circular_dependency_broken_by_lazy.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/circular_dependency_broken_by_lazy.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/circular_dependency_direct.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/circular_dependency_direct.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/circular_dependency_transitive.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/circular_dependency_transitive.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class TestModule : R|kotlin/Any| {
         public constructor(): R|testpkg/TestModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/configuration_label_mismatch.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/configuration_label_mismatch.fir.txt
@@ -20,13 +20,13 @@ FILE: Service.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core))) @R|org/koin/core/annotation/Configuration|(value = vararg(String(core))) public final class CoreModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(core)) [evaluated = vararg(String(core))]) @R|org/koin/core/annotation/Configuration|(value = vararg(String(core)) [evaluated = vararg(String(core))]) public final class CoreModule : R|kotlin/Any| {
         public constructor(): R|CoreModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) @R|org/koin/core/annotation/Configuration|(value = vararg(String(service))) public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) @R|org/koin/core/annotation/Configuration|(value = vararg(String(service)) [evaluated = vararg(String(service))]) public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/missing_viewmodel_artifact.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/missing_viewmodel_artifact.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class AppModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class AppModule : R|kotlin/Any| {
         public constructor(): R|testpkg/AppModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/missing_worker_artifact.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/missing_worker_artifact.fir.txt
@@ -1,7 +1,7 @@
 FILE: test.kt
     package testpkg
 
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class AppModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg)) [evaluated = vararg(String(testpkg))]) public final class AppModule : R|kotlin/Any| {
         public constructor(): R|testpkg/AppModule| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/qualifier_mismatch.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/qualifier_mismatch.fir.txt
@@ -5,14 +5,14 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(test)) public final class Repository : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Singleton|() @R|org/koin/core/annotation/Named|(value = String(test) [evaluated = String(test)]) public final class Repository : R|kotlin/Any| {
         public constructor(): R|Repository| {
             super<R|kotlin/Any|>()
         }
 
     }
     @R|org/koin/core/annotation/Singleton|() public final class Service : R|kotlin/Any| {
-        public constructor(@R|org/koin/core/annotation/Named|(value = String(prod)) repo: R|Repository|): R|Service| {
+        public constructor(@R|org/koin/core/annotation/Named|(value = String(prod) [evaluated = String(prod)]) repo: R|Repository|): R|Service| {
             super<R|kotlin/Any|>()
         }
 

--- a/koin-compiler-plugin/testData/diagnostics/scoped_cross_scope.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/scoped_cross_scope.fir.txt
@@ -17,7 +17,7 @@ FILE: test.kt
         }
 
     }
-    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|SessionScope|)) public final class Service : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|SessionScope|) [evaluated = <getClass>(Q|SessionScope|)]) public final class Service : R|kotlin/Any| {
         public constructor(auth: R|AuthData|): R|Service| {
             super<R|kotlin/Any|>()
         }
@@ -26,7 +26,7 @@ FILE: test.kt
             public get(): R|AuthData|
 
     }
-    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|UserScope|)) public final class AuthData : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Scoped|() @R|org/koin/core/annotation/Scope|(value = <getClass>(Q|UserScope|) [evaluated = <getClass>(Q|UserScope|)]) public final class AuthData : R|kotlin/Any| {
         public constructor(): R|AuthData| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-plugin/testData/diagnostics/startkoin_missing.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/startkoin_missing.fir.txt
@@ -17,13 +17,13 @@ FILE: Service.kt
 
     }
 FILE: modules.kt
-    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service))) public final class ServiceModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(service)) [evaluated = vararg(String(service))]) public final class ServiceModule : R|kotlin/Any| {
         public constructor(): R|ServiceModule| {
             super<R|kotlin/Any|>()
         }
 
     }
-    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|ServiceModule|))) public final object MyApp : R|kotlin/Any| {
+    @R|org/koin/core/annotation/KoinApplication|(modules = <collectionLiteralCall>(<getClass>(Q|ServiceModule|)) [evaluated = <collectionLiteralCall>(<getClass>(Q|ServiceModule|))]) public final object MyApp : R|kotlin/Any| {
         private constructor(): R|MyApp| {
             super<R|kotlin/Any|>()
         }

--- a/koin-compiler-version-adapter/src/org/koin/compiler/adapter/KotlinAdapterLoader.kt
+++ b/koin-compiler-version-adapter/src/org/koin/compiler/adapter/KotlinAdapterLoader.kt
@@ -50,22 +50,23 @@ object KotlinAdapterLoader {
         val newest = registry.last()
         val warnings = mutableListOf<String>()
 
-        val current = KotlinReleaseVersion.parseOrNull(compilerVersion)
+        val effectiveCompilerVersion = effectiveCompilerVersion(compilerVersion, warnings)
+        val current = KotlinReleaseVersion.parseOrNull(effectiveCompilerVersion)
         val entry = when {
             current == null -> {
-                warnings += "Koin compiler plugin: unrecognized Kotlin version '$compilerVersion' — using the adapter for Kotlin ${newest.first.raw} (newest available). Supported versions: ${supportedList(registry)}."
+                warnings += "Koin compiler plugin: unrecognized Kotlin version '$effectiveCompilerVersion' — using the adapter for Kotlin ${newest.first.raw} (newest available). Supported versions: ${supportedList(registry)}."
                 newest
             }
             else -> registry.lastOrNull { current.lineAtLeast(it.first) }
                 ?: return Selection(
                     null, warnings,
-                    "Koin compiler plugin: Kotlin $compilerVersion is older than the oldest supported version (${registry.first().first.raw}). " +
+                    "Koin compiler plugin: Kotlin $effectiveCompilerVersion is older than the oldest supported version (${registry.first().first.raw}). " +
                         "Upgrade Kotlin or use a koin-compiler-plugin release matching your Kotlin version. Supported versions: ${supportedList(registry)}.",
                 )
         }
 
         if (current != null && !newest.first.lineAtLeast(current)) {
-            warnings += "Koin compiler plugin: Kotlin $compilerVersion is newer than the newest tested version (${newest.first.raw}) — proceeding with the ${newest.first.raw} adapter. " +
+            warnings += "Koin compiler plugin: Kotlin $effectiveCompilerVersion is newer than the newest tested version (${newest.first.raw}) — proceeding with the ${newest.first.raw} adapter. " +
                 "If compilation fails, check for a koin-compiler-plugin update. Supported versions: ${supportedList(registry)}."
         }
 
@@ -76,9 +77,37 @@ object KotlinAdapterLoader {
             loaded = adapter
             Selection(adapter, warnings, null)
         } catch (e: Throwable) {
-            Selection(null, warnings, "Koin compiler plugin: failed to load Kotlin version adapter '${entry.second}' for Kotlin $compilerVersion: $e")
+            Selection(null, warnings, "Koin compiler plugin: failed to load Kotlin version adapter '${entry.second}' for Kotlin $effectiveCompilerVersion: $e")
         }
     }
+
+    /**
+     * Gradle's Build Tools API path can expose a compiler API newer than the
+     * `KotlinCompilerVersion.VERSION` constant visible to the plugin classloader.
+     * Kotlin 2.4.0 changed FIR extension registration from ProjectExtensionDescriptor
+     * to ExtensionPointDescriptor; if that shape is present, the 2.3 adapter is
+     * guaranteed to fail even when the reported version still looks like 2.3.x.
+     */
+    private fun effectiveCompilerVersion(reportedVersion: String, warnings: MutableList<String>): String {
+        if (!requiresKotlin240FirRegistrationApi()) return reportedVersion
+
+        val reported = KotlinReleaseVersion.parseOrNull(reportedVersion)
+        val kotlin240 = KotlinReleaseVersion.parseOrNull("2.4.0") ?: return reportedVersion
+        if (reported != null && reported.lineAtLeast(kotlin240)) return reportedVersion
+
+        warnings += "Koin compiler plugin: Kotlin reports '$reportedVersion' but exposes the Kotlin 2.4 FIR extension registration API — using the Kotlin 2.4.0 adapter."
+        return "2.4.0"
+    }
+
+    private fun requiresKotlin240FirRegistrationApi(): Boolean =
+        try {
+            val registrarAdapter = Class.forName("org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter")
+            val companion = registrarAdapter.getField("Companion").get(null)
+            val projectExtensionDescriptor = Class.forName("org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor")
+            !projectExtensionDescriptor.isInstance(companion)
+        } catch (_: Throwable) {
+            false
+        }
 
     /** Registry entries sorted by Kotlin version, oldest first. */
     private fun readRegistry(): List<Pair<KotlinReleaseVersion, String>> {

--- a/playground-apps/app-annotations/app/build.gradle.kts
+++ b/playground-apps/app-annotations/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.koin.compiler)

--- a/playground-apps/app-annotations/build.gradle.kts
+++ b/playground-apps/app-annotations/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.koin.compiler) apply false

--- a/playground-apps/app-annotations/core/analytics/build.gradle.kts
+++ b/playground-apps/app-annotations/core/analytics/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-annotations/core/common/build.gradle.kts
+++ b/playground-apps/app-annotations/core/common/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-annotations/core/data/build.gradle.kts
+++ b/playground-apps/app-annotations/core/data/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-annotations/core/database/build.gradle.kts
+++ b/playground-apps/app-annotations/core/database/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
     alias(libs.plugins.room)
     alias(libs.plugins.ksp)

--- a/playground-apps/app-annotations/core/datastore/build.gradle.kts
+++ b/playground-apps/app-annotations/core/datastore/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-annotations/core/domain/build.gradle.kts
+++ b/playground-apps/app-annotations/core/domain/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-annotations/core/model/build.gradle.kts
+++ b/playground-apps/app-annotations/core/model/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/playground-apps/app-annotations/core/network/build.gradle.kts
+++ b/playground-apps/app-annotations/core/network/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-annotations/core/notifications/build.gradle.kts
+++ b/playground-apps/app-annotations/core/notifications/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-annotations/feature/bookmarks/build.gradle.kts
+++ b/playground-apps/app-annotations/feature/bookmarks/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.koin.compiler)
 }

--- a/playground-apps/app-annotations/feature/detail/build.gradle.kts
+++ b/playground-apps/app-annotations/feature/detail/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.koin.compiler)
 }

--- a/playground-apps/app-annotations/feature/home/build.gradle.kts
+++ b/playground-apps/app-annotations/feature/home/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.koin.compiler)
 }

--- a/playground-apps/app-annotations/feature/settings/build.gradle.kts
+++ b/playground-apps/app-annotations/feature/settings/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.koin.compiler)
 }

--- a/playground-apps/app-annotations/gradle/libs.versions.toml
+++ b/playground-apps/app-annotations/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-agp = "8.13.2"
+agp = "9.2.1"
 kotlin = "2.4.0"
 koin = "4.2.1"
 koin-plugin = "1.0.1"
 composeBom = "2026.03.00"
 navigation = "2.9.7"
 room = "2.8.4"
-ksp = "2.3.3"
+ksp = "2.3.9"
 datastore = "1.2.1"
 workmanager = "2.11.1"
 serialization = "1.10.0"
@@ -56,7 +56,6 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 koin-compiler = { id = "io.insert-koin.compiler.plugin", version.ref = "koin-plugin" }

--- a/playground-apps/app-annotations/gradle/wrapper/gradle-wrapper.properties
+++ b/playground-apps/app-annotations/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/playground-apps/app-annotations/sync/work/build.gradle.kts
+++ b/playground-apps/app-annotations/sync/work/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-dsl/app/build.gradle.kts
+++ b/playground-apps/app-dsl/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.koin.compiler)

--- a/playground-apps/app-dsl/build.gradle.kts
+++ b/playground-apps/app-dsl/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.koin.compiler) apply false

--- a/playground-apps/app-dsl/core/analytics/build.gradle.kts
+++ b/playground-apps/app-dsl/core/analytics/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-dsl/core/common/build.gradle.kts
+++ b/playground-apps/app-dsl/core/common/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-dsl/core/data/build.gradle.kts
+++ b/playground-apps/app-dsl/core/data/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-dsl/core/database/build.gradle.kts
+++ b/playground-apps/app-dsl/core/database/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
     alias(libs.plugins.room)
     alias(libs.plugins.ksp)

--- a/playground-apps/app-dsl/core/datastore/build.gradle.kts
+++ b/playground-apps/app-dsl/core/datastore/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-dsl/core/domain/build.gradle.kts
+++ b/playground-apps/app-dsl/core/domain/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-dsl/core/model/build.gradle.kts
+++ b/playground-apps/app-dsl/core/model/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/playground-apps/app-dsl/core/network/build.gradle.kts
+++ b/playground-apps/app-dsl/core/network/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-dsl/core/notifications/build.gradle.kts
+++ b/playground-apps/app-dsl/core/notifications/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-dsl/feature/bookmarks/build.gradle.kts
+++ b/playground-apps/app-dsl/feature/bookmarks/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.koin.compiler)
 }

--- a/playground-apps/app-dsl/feature/detail/build.gradle.kts
+++ b/playground-apps/app-dsl/feature/detail/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.koin.compiler)
 }

--- a/playground-apps/app-dsl/feature/home/build.gradle.kts
+++ b/playground-apps/app-dsl/feature/home/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.koin.compiler)
 }

--- a/playground-apps/app-dsl/feature/settings/build.gradle.kts
+++ b/playground-apps/app-dsl/feature/settings/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.koin.compiler)
 }

--- a/playground-apps/app-dsl/gradle/libs.versions.toml
+++ b/playground-apps/app-dsl/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-agp = "8.13.2"
+agp = "9.2.1"
 kotlin = "2.4.0"
 koin = "4.2.1"
 koin-plugin = "1.0.1"
 composeBom = "2026.03.00"
 navigation = "2.9.7"
 room = "2.8.4"
-ksp = "2.3.3"
+ksp = "2.3.9"
 datastore = "1.2.1"
 workmanager = "2.11.1"
 serialization = "1.10.0"
@@ -53,7 +53,6 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 koin-compiler = { id = "io.insert-koin.compiler.plugin", version.ref = "koin-plugin" }

--- a/playground-apps/app-dsl/gradle/wrapper/gradle-wrapper.properties
+++ b/playground-apps/app-dsl/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/playground-apps/app-dsl/sync/work/build.gradle.kts
+++ b/playground-apps/app-dsl/sync/work/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.koin.compiler)
 }
 

--- a/playground-apps/app-floor-2320/gradle/wrapper/gradle-wrapper.properties
+++ b/playground-apps/app-floor-2320/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/test-apps/gradle/libs.versions.toml
+++ b/test-apps/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 koin = "4.2.1"
-koin-plugin = "1.0.0"
+koin-plugin = "1.0.1"
 
 [libraries]
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }

--- a/test-apps/gradle/wrapper/gradle-wrapper.properties
+++ b/test-apps/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/test-apps/sample-app/src/jvmMain/kotlin/examples/annotations/AnnotationsConfigTest.kt
+++ b/test-apps/sample-app/src/jvmMain/kotlin/examples/annotations/AnnotationsConfigTest.kt
@@ -1,10 +1,15 @@
 package examples.annotations
 
+import feature.FeatureService
+import feature.PremiumConsumer
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Configuration
 import org.koin.core.annotation.KoinApplication
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Singleton
+import org.koin.core.context.stopKoin
+import org.koin.core.logger.Level
+import org.koin.plugin.module.dsl.startKoin
 
 @Module
 @ComponentScan
@@ -17,3 +22,18 @@ class ConfigSingle
 // @Configuration modules are auto-discovered - no need for explicit modules parameter!
 @KoinApplication
 object MyApp2
+
+fun main() {
+    val koin = startKoin<MyApp2> {
+        printLogger(Level.DEBUG)
+    }.koin
+
+    try {
+        check(koin.getOrNull<ConfigSingle>() != null) { "ConfigSingle should be resolved from MyModule2" }
+        check(koin.getOrNull<FeatureService>() != null) { "FeatureService should be resolved from FeatureModule" }
+        check(koin.getOrNull<PremiumConsumer>() != null) { "PremiumConsumer should be resolved from FeatureModule" }
+        println("OK")
+    } finally {
+        stopKoin()
+    }
+}


### PR DESCRIPTION
## Summary

- Fix Kotlin 2.4 FIR extension registration by selecting the Kotlin 2.4 adapter when the compiler exposes the new FIR registration API.
- Update the compiler project to Kotlin 2.4.0 and Gradle 9.5.1.
- Refresh generated compiler test data for Kotlin 2.4.0.
- Update sample apps to use `io.insert-koin.compiler.plugin:1.0.1`.
- Migrate Android playgrounds to AGP 9.2.1 built-in Kotlin and update KSP to 2.3.9.
- Document Kotlin 2.4 compatibility in README.

## Verification

- `./gradlew check --stacktrace`
- `./gradlew publishToMavenLocal --no-configuration-cache --stacktrace`
- `cd test-apps && ./gradlew :sample-app:jvmTest :sample-app:jvmRun --stacktrace`
- `cd playground-apps/app-dsl && ANDROID_HOME=/Users/User/Library/Android/sdk ./gradlew :app:assembleDebug --stacktrace`
- `cd playground-apps/app-annotations && ANDROID_HOME=/Users/User/Library/Android/sdk ./gradlew :app:assembleDebug --stacktrace`