### PR TITLE
Attach resolvable source to IR-generated hint files (wasmJs/JS KLIB)

### DIFF
--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/CallSiteValidator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/CallSiteValidator.kt
@@ -239,13 +239,6 @@ class CallSiteValidator(private val context: IrPluginContext) {
                 .replaceFirstChar { it.lowercaseChar() }
             val fileName = "${modulePrefix}${sanitizedName}_callsite.kt"
 
-            val firFile = buildFile {
-                moduleData = firModuleData
-                origin = FirDeclarationOrigin.Synthetic.PluginFile
-                packageDirective = buildPackageDirective { packageFqName = hintsPackage }
-                name = fileName
-            }
-
             // Anchor the synthetic hint file on the call site's source file so the path stays
             // stable across incremental rebuilds (see issue #32). Fall back to the
             // alphabetically-first source file in the module — also stable, just less local.
@@ -253,6 +246,16 @@ class CallSiteValidator(private val context: IrPluginContext) {
                 ?: moduleFragment.files.minByOrNull { it.fileEntry.name }?.fileEntry?.name
                 ?: "/synthetic"
             val fakeNewPath = Path(basePath).parent.resolve(fileName)
+
+            val firFile = buildFile {
+                moduleData = firModuleData
+                origin = FirDeclarationOrigin.Synthetic.PluginFile
+                packageDirective = buildPackageDirective { packageFqName = hintsPackage }
+                name = fileName
+                // KLIB metadata serialization (Native/JS/Wasm) requires a resolvable io
+                // File per file; a null sourceFile fails the wasm/js serializer (KT-82395).
+                sourceFile = syntheticHintSourceFile(fakeNewPath.absolutePathString())
+            }
 
             val hintFile = IrFileImpl(
                 fileEntry = NaiveSourceBasedFileEntryImpl(fakeNewPath.absolutePathString()),

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DslHintGenerator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DslHintGenerator.kt
@@ -223,13 +223,6 @@ class DslHintGenerator(private val context: IrPluginContext) {
             val prefix = HintFilePrefix.of(firModuleData.name.asString())
             val fileName = prefix + buildDslHintFileName(targetClassId, hintName)
 
-            val firFile = buildFile {
-                moduleData = firModuleData
-                origin = FirDeclarationOrigin.Synthetic.PluginFile
-                packageDirective = buildPackageDirective { packageFqName = hintsPackage }
-                name = fileName
-            }
-
             // Anchor the synthetic hint file on a stable source path from the current compile
             // unit (see issue #32). Priority:
             //   1. The DSL call's own source file — always a file in the current module, and
@@ -250,6 +243,16 @@ class DslHintGenerator(private val context: IrPluginContext) {
                 ?: moduleFragment.files.minByOrNull { it.fileEntry.name }?.fileEntry?.name
                 ?: "/synthetic"
             val fakeNewPath = Path(basePath).parent.resolve(fileName)
+
+            val firFile = buildFile {
+                moduleData = firModuleData
+                origin = FirDeclarationOrigin.Synthetic.PluginFile
+                packageDirective = buildPackageDirective { packageFqName = hintsPackage }
+                name = fileName
+                // KLIB metadata serialization (Native/JS/Wasm) requires a resolvable io
+                // File per file; a null sourceFile fails the wasm/js serializer (KT-82395).
+                sourceFile = syntheticHintSourceFile(fakeNewPath.absolutePathString())
+            }
 
             val hintFile = IrFileImpl(
                 fileEntry = NaiveSourceBasedFileEntryImpl(fakeNewPath.absolutePathString()),

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/InjectedParamHintGenerator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/InjectedParamHintGenerator.kt
@@ -111,8 +111,15 @@ class InjectedParamHintGenerator(
                 KoinPluginLogger.debug { "InjectedParam: ambiguous target $targetFqName (multiple definitions, different @InjectedParam shapes) — skipping index" }
                 continue
             }
-            localSlots.putIfAbsent(targetFqName, slots)
-            emitHintFunction(moduleFragment, def, targetClass, targetFqName, slots)
+            // Emit the hint exactly once per target. Multiple definitions can share a
+            // target+shape (e.g. an annotation definition and a DSL definition for the
+            // same type); since they passed the ambiguity check they have identical
+            // shapes, so a single hint is correct. Emitting per-definition produces
+            // duplicate IR functions with identical signatures — tolerated on JVM but
+            // a hard KLIB serialization failure on Native/JS/Wasm (compiler#40, #44).
+            if (localSlots.putIfAbsent(targetFqName, slots) == null) {
+                emitHintFunction(moduleFragment, def, targetClass, targetFqName, slots)
+            }
         }
 
         if (localSlots.isNotEmpty()) {

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/InjectedParamHintGenerator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/InjectedParamHintGenerator.kt
@@ -299,12 +299,6 @@ class InjectedParamHintGenerator(
         // for the same target type don't produce identical class names at dex merge time.
         val modulePrefix = HintFilePrefix.of(firModuleData.name.asString())
         val fileName = "${modulePrefix}${KoinPluginConstants.INJECTED_PARAMS_HINT_PREFIX}${flat}.kt"
-        val firFile = buildFile {
-            moduleData = firModuleData
-            origin = FirDeclarationOrigin.Synthetic.PluginFile
-            packageDirective = buildPackageDirective { packageFqName = hintsPackage }
-            name = fileName
-        }
         // Anchor the synthetic hint file on a stable path from the current compile unit
         // (see issue #32). Priority: DSL registration site → target class source → sorted
         // first file in module. Mirrors [DslHintGenerator.generateDslDefinitionHints].
@@ -320,6 +314,16 @@ class InjectedParamHintGenerator(
             ?: moduleFragment.files.minByOrNull { it.fileEntry.name }?.fileEntry?.name
             ?: "/synthetic"
         val fakeNewPath = Path(basePath).parent.resolve(fileName)
+
+        val firFile = buildFile {
+            moduleData = firModuleData
+            origin = FirDeclarationOrigin.Synthetic.PluginFile
+            packageDirective = buildPackageDirective { packageFqName = hintsPackage }
+            name = fileName
+            // KLIB metadata serialization (Native/JS/Wasm) requires a resolvable io File
+            // per file; a null sourceFile fails the wasm/js serializer (KT-82395).
+            sourceFile = syntheticHintSourceFile(fakeNewPath.absolutePathString())
+        }
 
         val hintFile = IrFileImpl(
             fileEntry = NaiveSourceBasedFileEntryImpl(fakeNewPath.absolutePathString()),

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinAnnotationProcessor.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinAnnotationProcessor.kt
@@ -1003,12 +1003,6 @@ class KoinAnnotationProcessor(
             }
 
             val batchFileName = "koin_hints_${sanitizedModuleId}.kt"
-            val firFile = buildFile {
-                moduleData = firModuleData
-                origin = FirDeclarationOrigin.Synthetic.PluginFile
-                packageDirective = buildPackageDirective { packageFqName = hintsPackage }
-                name = batchFileName
-            }
 
             val sourceFileEntry = try {
                 moduleClass.irClass.fileEntry
@@ -1021,6 +1015,17 @@ class KoinAnnotationProcessor(
             }
 
             val fakeNewPath = Path(sourceFileEntry.name).parent.resolve(batchFileName)
+            val firFile = buildFile {
+                moduleData = firModuleData
+                origin = FirDeclarationOrigin.Synthetic.PluginFile
+                packageDirective = buildPackageDirective { packageFqName = hintsPackage }
+                name = batchFileName
+                // KLIB metadata serialization (Native/JS/Wasm) requires every file to
+                // resolve to an io File; a synthetic file with no sourceFile fails the
+                // wasm/js serializer with "No file found for source null" (KT-82395).
+                sourceFile = syntheticHintSourceFile(fakeNewPath.absolutePathString())
+            }
+
             val hintFile = IrFileImpl(
                 fileEntry = NaiveSourceBasedFileEntryImpl(fakeNewPath.absolutePathString()),
                 packageFragmentDescriptor = EmptyPackageFragmentDescriptor(

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/SyntheticHintSourceFile.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/SyntheticHintSourceFile.kt
@@ -1,0 +1,21 @@
+package org.koin.compiler.plugin.ir
+
+import org.jetbrains.kotlin.KtIoFileSourceFile
+import org.jetbrains.kotlin.KtSourceFile
+import java.io.File
+
+/**
+ * Source file attached to the synthetic FIR files the plugin generates for hints.
+ *
+ * KLIB metadata serialization walks every file in the module and resolves it to an
+ * io [File] (`serializeModuleIntoKlib` → `KtSourceFile.toIoFileOrNull()`). A synthetic
+ * file with no `sourceFile` resolves to `null`, which the Native backend tolerates but
+ * the JS/Wasm serializer rejects with `IllegalStateException: No file found for source
+ * null` (KT-82395). Anchoring the file on a [KtIoFileSourceFile] — even a path that is
+ * not a real on-disk file — gives the serializer a non-null io File and keeps wasm/js
+ * builds working.
+ *
+ * [path] should be the hint file's own deterministic path (the same value used for the
+ * IR `fileEntry`), so the FIR source and IR file entry agree.
+ */
+internal fun syntheticHintSourceFile(path: String): KtSourceFile = KtIoFileSourceFile(File(path))

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -329,6 +329,12 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     }
 
     @Test
+    @TestMetadata("injected_param_dual_definition_single_hint.kt")
+    public void testInjected_param_dual_definition_single_hint() {
+      runTest("koin-compiler-plugin/testData/box/safety/injected_param_dual_definition_single_hint.kt");
+    }
+
+    @Test
     @TestMetadata("injected_param_ok.kt")
     public void testInjected_param_ok() {
       runTest("koin-compiler-plugin/testData/box/safety/injected_param_ok.kt");

--- a/koin-compiler-plugin/testData/box/safety/injected_param_dual_definition_single_hint.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/safety/injected_param_dual_definition_single_hint.fir.ir.txt
@@ -1,0 +1,187 @@
+FILE fqName:<root> fileName:/firstModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.FirstModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: <root>.FirstModule): org.koin.core.module.Module declared in <root>'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                CALL 'public final fun buildFactory <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildFactory>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildFactory>): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildFactory> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildFactory> origin=null
+                  TYPE_ARG T: <root>.Greeter
+                  ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Greeter>
+                  ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.Greeter> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.Greeter
+                      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                      VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.Greeter declared in <root>.module.<anonymous>'
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String) declared in <root>.Greeter' type=<root>.Greeter origin=null
+                            ARG name: CALL 'public final fun get <T> (): T of org.koin.core.parameter.ParametersHolder.get declared in org.koin.core.parameter.ParametersHolder' type=kotlin.String origin=null
+                              TYPE_ARG T: kotlin.String
+                              ARG <this>: GET_VAR 'params: org.koin.core.parameter.ParametersHolder declared in <root>.module.<anonymous>.<anonymous>' type=org.koin.core.parameter.ParametersHolder origin=null
+FILE fqName:org.koin.plugin.hints fileName:/koin_hints_firstModule.kt
+  FUN name:componentscan_firstModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Greeter
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:org.koin.plugin.hints fileName:/koin_hints_secondModule.kt
+  FUN name:componentscan_secondModule_factory visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Greeter
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:org.koin.plugin.hints fileName:/main__injectedparams_Greeter.kt
+  FUN name:injectedparams_Greeter visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:<root> fileName:/secondModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.SecondModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: <root>.SecondModule): org.koin.core.module.Module declared in <root>'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                CALL 'public final fun buildFactory <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildFactory>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildFactory>): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildFactory> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildFactory> origin=null
+                  TYPE_ARG T: <root>.Greeter
+                  ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Greeter>
+                  ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.Greeter> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.Greeter
+                      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                      VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.Greeter declared in <root>.module.<anonymous>'
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String) declared in <root>.Greeter' type=<root>.Greeter origin=null
+                            ARG name: CALL 'public final fun get <T> (): T of org.koin.core.parameter.ParametersHolder.get declared in org.koin.core.parameter.ParametersHolder' type=kotlin.String origin=null
+                              TYPE_ARG T: kotlin.String
+                              ARG <this>: GET_VAR 'params: org.koin.core.parameter.ParametersHolder declared in <root>.module.<anonymous>.<anonymous>' type=org.koin.core.parameter.ParametersHolder origin=null
+FILE fqName:<root> fileName:/test.kt
+  CLASS CLASS name:FirstModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.FirstModule
+    CONSTRUCTOR visibility:public returnType:<root>.FirstModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:FirstModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Factory(binds = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Greeter
+    PROPERTY name:name visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'name: kotlin.String declared in <root>.Greeter.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Greeter
+        correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.Greeter'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Greeter declared in <root>.Greeter.<get-name>' type=<root>.Greeter origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Greeter [primary]
+      VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
+        annotations:
+          InjectedParam
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Greeter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:SecondModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.SecondModule
+    CONSTRUCTOR visibility:public returnType:<root>.SecondModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:SecondModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (vararg modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: VARARG type=kotlin.Array<out org.koin.core.module.Module> varargElementType=org.koin.core.module.Module
+                        CALL 'public final fun module (<this>: <root>.FirstModule): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=null
+                          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.FirstModule' type=<root>.FirstModule origin=null
+                        CALL 'public final fun module (<this>: <root>.SecondModule): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=null
+                          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.SecondModule' type=<root>.SecondModule origin=null
+      VAR name:greeter type:<root>.Greeter [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.Greeter origin=null
+          TYPE_ARG T: <root>.Greeter
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+          ARG parameters: FUN_EXPR type=kotlin.Function0<org.koin.core.parameter.ParametersHolder> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:org.koin.core.parameter.ParametersHolder
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): org.koin.core.parameter.ParametersHolder declared in <root>.box'
+                  CALL 'public final fun parametersOf (vararg parameters: kotlin.Any?): org.koin.core.parameter.ParametersHolder declared in org.koin.core.parameter' type=org.koin.core.parameter.ParametersHolder origin=null
+                    ARG parameters: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                      CONST String type=kotlin.String value="World"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              ARG arg0: CALL 'public final fun <get-name> (): kotlin.String declared in <root>.Greeter' type=kotlin.String origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val greeter: <root>.Greeter declared in <root>.box' type=<root>.Greeter origin=null
+              ARG arg1: CONST String type=kotlin.String value="World"
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CONST String type=kotlin.String value="FAIL: @InjectedParam not working"

--- a/koin-compiler-plugin/testData/box/safety/injected_param_dual_definition_single_hint.fir.txt
+++ b/koin-compiler-plugin/testData/box/safety/injected_param_dual_definition_single_hint.fir.txt
@@ -1,0 +1,45 @@
+FILE: test.kt
+    @R|org/koin/core/annotation/Factory|() public final class Greeter : R|kotlin/Any| {
+        public constructor(@R|org/koin/core/annotation/InjectedParam|() name: R|kotlin/String|): R|Greeter| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val name: R|kotlin/String| = R|<local>/name|
+            public get(): R|kotlin/String|
+
+    }
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|() public final class FirstModule : R|kotlin/Any| {
+        public constructor(): R|FirstModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|() public final class SecondModule : R|kotlin/Any| {
+        public constructor(): R|SecondModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(vararg(R|/FirstModule.FirstModule|().R|/module|(), R|/SecondModule.SecondModule|().R|/module|()))
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval greeter: R|Greeter| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|Greeter|>(<L> = get@fun <anonymous>(): R|org/koin/core/parameter/ParametersHolder| <inline=NoInline>  {
+            ^ R|org/koin/core/parameter/parametersOf|(vararg(String(World)))
+        }
+        )
+        ^box when () {
+            ==(R|<local>/greeter|.R|/Greeter.name|, String(World)) ->  {
+                String(OK)
+            }
+            else ->  {
+                String(FAIL: @InjectedParam not working)
+            }
+        }
+
+    }
+FILE: /firstModuleModule.kt
+    public final fun R|FirstModule|.module(): R|org/koin/core/module/Module|
+FILE: /secondModuleModule.kt
+    public final fun R|SecondModule|.module(): R|org/koin/core/module/Module|

--- a/koin-compiler-plugin/testData/box/safety/injected_param_dual_definition_single_hint.kt
+++ b/koin-compiler-plugin/testData/box/safety/injected_param_dual_definition_single_hint.kt
@@ -1,0 +1,38 @@
+// FILE: test.kt
+import org.koin.dsl.koinApplication
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
+import org.koin.core.parameter.parametersOf
+
+// Regression for compiler#40 / #44 (KTZ-4151): when the SAME @InjectedParam target
+// is collected by more than one module — here two @ComponentScan modules over the
+// same package — getAllKnownDefinitions() returns it twice with identical target +
+// @InjectedParam shape. The plugin must still emit the `injectedparams_*` hint
+// function exactly ONCE. Emitting per-definition produced duplicate IR functions
+// with identical signatures: tolerated on JVM, but a hard KLIB serialization
+// failure on Native/JS/Wasm ("Different declarations with the same signatures").
+//
+// The .fir.ir.txt golden for this test must contain a single
+// `injectedparams_<...>Greeter` FUN declaration.
+
+@Factory
+class Greeter(@InjectedParam val name: String)
+
+@Module
+@ComponentScan
+class FirstModule
+
+@Module
+@ComponentScan
+class SecondModule
+
+fun box(): String {
+    val koin = koinApplication {
+        modules(FirstModule().module(), SecondModule().module())
+    }.koin
+
+    val greeter = koin.get<Greeter> { parametersOf("World") }
+    return if (greeter.name == "World") "OK" else "FAIL: @InjectedParam not working"
+}

--- a/playground-apps/app-kmp-klib/.gitignore
+++ b/playground-apps/app-kmp-klib/.gitignore
@@ -1,0 +1,5 @@
+build/
+.gradle/
+.kotlin/
+local.properties
+kotlin-js-store/

--- a/playground-apps/app-kmp-klib/README.md
+++ b/playground-apps/app-kmp-klib/README.md
@@ -1,0 +1,43 @@
+# app-kmp-klib — KLIB target regression sample
+
+A minimal Kotlin Multiplatform app exercising the **KLIB-serialized** targets
+(`wasmJs`, `iosArm64`) that the JVM box tests can't cover. It is the repro behind
+compiler **#40** (wasmJs) and **#44** (iOS).
+
+`App.kt` declares the same `@InjectedParam` target collected by **two
+`@ComponentScan` modules** — the exact shape that emitted the `injectedparams_*`
+hint twice and broke KLIB serialization.
+
+## Build
+
+```bash
+# from the repo root: publish the plugin to mavenLocal first
+./install.sh
+
+cd playground-apps/app-kmp-klib
+../../gradlew compileKotlinIosArm64                          # Kotlin 2.3.20 (floor)
+../../gradlew compileKotlinIosArm64 -PkotlinVersion=2.4.0
+../../gradlew compileKotlinWasmJs
+../../gradlew compileKotlinWasmJs  -PkotlinVersion=2.4.0
+```
+
+## Expected results
+
+| Target | Kotlin 2.3.20 | Kotlin 2.4.0 |
+|---|---|---|
+| `iosArm64` (annotations) | ✅ | ✅ |
+| `wasmJs` (DSL) | ✅ | ✅ |
+| `wasmJs` (annotations / `@ComponentScan`) | ❌ `KT-82395` | ✅ |
+
+- **iOS** and **wasmJs-DSL** pass on both Kotlin versions — the duplicate-signature
+  fix (single hint per target) and the IR-hint source-attribution fix.
+- **wasmJs + annotations on Kotlin 2.3.20** fails with
+  `IllegalStateException: No file found for source null`. This is a **Kotlin 2.3.20
+  compiler bug** ([KT-82395](https://youtrack.jetbrains.com/issue/KT-82395)) in the
+  JS/Wasm KLIB metadata serializer: the FIR cross-module discovery hints are placed
+  in a framework-created file with no resolvable source. The Native backend tolerates
+  it; the 2.3.20 wasm/js backend does not. **Fixed by Kotlin 2.4.0** — use Kotlin
+  2.4.0 for annotation-based wasmJs.
+
+> Not wired as a CI gate: the wasmJs-annotation cell is Kotlin-version-dependent by
+> design (passes on 2.4.0, blocked by KT-82395 on 2.3.20).

--- a/playground-apps/app-kmp-klib/build.gradle.kts
+++ b/playground-apps/app-kmp-klib/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    kotlin("multiplatform")
+    id("io.insert-koin.compiler.plugin")
+}
+
+kotlin {
+    jvmToolchain(17)
+
+    // wasmJs: a KLIB target (no Xcode needed) — serialization rejects duplicate
+    // injectedparams_* signatures, the actual failure mode of compiler#40/#44.
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs {
+        nodejs()
+        binaries.executable()
+    }
+
+    // iOS device target — the failing target in compiler#44. KLIB-serialized like
+    // wasmJs, so it exercises the same duplicate-signature path on the native backend.
+    iosArm64()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("io.insert-koin:koin-core:4.2.1")
+                implementation("io.insert-koin:koin-annotations:4.2.1")
+            }
+        }
+    }
+}

--- a/playground-apps/app-kmp-klib/settings.gradle.kts
+++ b/playground-apps/app-kmp-klib/settings.gradle.kts
@@ -1,0 +1,24 @@
+// Multiplatform KLIB verification app — proves the injectedparams_* hint is emitted
+// once so KLIB serialization (wasmJs/native) succeeds. JVM tolerates duplicates;
+// this target is where compiler#40/#44 actually failed.
+pluginManagement {
+    val kotlinVersion: String = (settings.extra.properties["kotlinVersion"] as? String) ?: "2.3.20"
+    plugins {
+        kotlin("multiplatform") version kotlinVersion
+        id("io.insert-koin.compiler.plugin") version "1.0.1"
+    }
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "app-kmp-klib"

--- a/playground-apps/app-kmp-klib/src/commonMain/kotlin/playground/App.kt
+++ b/playground-apps/app-kmp-klib/src/commonMain/kotlin/playground/App.kt
@@ -1,0 +1,22 @@
+package playground
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
+import org.koin.core.annotation.Module
+
+// Same @InjectedParam target collected by two @ComponentScan modules — the case
+// that emitted the injectedparams_* hint twice and broke KLIB serialization
+// (compiler#40 wasmJs, #44 iOS). Compiling this to wasmJs is the real fix proof:
+// the KLIB serializer fails the build on duplicate signatures, passes on a single one.
+
+@Factory
+class Greeter(@InjectedParam val name: String)
+
+@Module
+@ComponentScan
+class FirstModule
+
+@Module
+@ComponentScan
+class SecondModule


### PR DESCRIPTION
## Problem

After the duplicate-signature fix (#55), wasmJs/JS still failed KLIB metadata serialization:

```
IllegalStateException: No file found for source null   (serializeModuleIntoKlib)
```

The plugin's synthetic hint files (injectedparams, DSL, call-site, annotation batch) were built with no `FirFile.sourceFile`. KLIB metadata serialization resolves every file to an io `File` (`KtSourceFile.toIoFileOrNull()`); a null source is tolerated by the Native backend but rejected by the JS/Wasm serializer.

## Fix

Attach a resolvable `KtIoFileSourceFile` (the hint file's own deterministic path) to all four synthetic `buildFile` sites, via shared helper `syntheticHintSourceFile()`.

## Verification

- Pure-DSL module now compiles to **wasmJs** (was the serialization error).
- Box suite unchanged (IR text dumps don't include source paths — no golden drift).
- Adds `playground-apps/app-kmp-klib`, a KLIB-target (wasmJs/iosArm64) regression sample.

## Scope note — annotation-based wasmJs

A separate path remains for annotation modules: the FIR-generated `module()` and cross-module `definition_*` discovery hints are placed in a **compiler-framework-created file** with no settable source. This is a **Kotlin 2.3.20 wasm/js serializer bug** ([KT-82395](https://youtrack.jetbrains.com/issue/KT-82395)) — **fixed in Kotlin 2.4.0** (verified: annotation-based wasmJs builds on 2.4.0, fails on 2.3.20). Not fixable in-plugin (`FirFile.sourceFile` has no setter). Guidance: use Kotlin 2.4.0 for annotation-based wasmJs.

Refs #40

> Stacked on #55 → #52. Merge those first; this PR's diff narrows afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
