### PR TITLE
Fix @Single(createdAtStart=true) silently dropped on definition functions

### DIFF
--- a/koin-compiler-plugin/testData/box/annotations/single_fun_created_at_start.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/single_fun_created_at_start.fir.ir.txt
@@ -1,10 +1,35 @@
+FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testModule.kt
+  FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.EagerClass
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+  FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.LazyClass
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
 FILE fqName:<root> fileName:/test.kt
-  CLASS CLASS name:Eager modality:FINAL visibility:public superTypes:[kotlin.Any]
-    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Eager
-    CONSTRUCTOR visibility:public returnType:<root>.Eager [primary]
+  CLASS CLASS name:EagerClass modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Singleton(binds = <null>, createdAtStart = true)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.EagerClass
+    ANONYMOUS_INITIALIZER isStatic=false
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
+              CALL 'public final fun <get-eagerClassCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+            CALL 'public final fun <set-eagerClassCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_0: kotlin.Int declared in <root>.EagerClass' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_0: kotlin.Int declared in <root>.EagerClass' type=kotlin.Int origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.EagerClass [primary]
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
-        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Eager modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:EagerClass modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
@@ -18,12 +43,64 @@ FILE fqName:<root> fileName:/test.kt
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
-  CLASS CLASS name:Lazy modality:FINAL visibility:public superTypes:[kotlin.Any]
-    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Lazy
-    CONSTRUCTOR visibility:public returnType:<root>.Lazy [primary]
+  CLASS CLASS name:EagerFromFun modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.EagerFromFun
+    CONSTRUCTOR visibility:public returnType:<root>.EagerFromFun [primary]
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
-        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Lazy modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:EagerFromFun modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:LazyClass modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Singleton(binds = <null>, createdAtStart = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.LazyClass
+    ANONYMOUS_INITIALIZER isStatic=false
+      BLOCK_BODY
+        TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+          BLOCK type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
+              CALL 'public final fun <get-lazyClassCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+            CALL 'public final fun <set-lazyClassCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=POSTFIX_INCR
+              ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+              ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
+                ARG <this>: GET_VAR 'val tmp_1: kotlin.Int declared in <root>.LazyClass' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_1: kotlin.Int declared in <root>.LazyClass' type=kotlin.Int origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.LazyClass [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:LazyClass modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:LazyFromFun modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.LazyFromFun
+    CONSTRUCTOR visibility:public returnType:<root>.LazyFromFun [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:LazyFromFun modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
@@ -40,6 +117,7 @@ FILE fqName:<root> fileName:/test.kt
   CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]
     annotations:
       Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = <null>)
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestModule
     CONSTRUCTOR visibility:public returnType:<root>.TestModule [primary]
       BLOCK_BODY
@@ -58,80 +136,118 @@ FILE fqName:<root> fileName:/test.kt
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
-    FUN name:eager visibility:public modality:FINAL returnType:<root>.Eager
+    FUN name:eagerFun visibility:public modality:FINAL returnType:<root>.EagerFromFun
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestModule
       annotations:
         Single(binds = <null>, createdAtStart = true)
       BLOCK_BODY
         TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
           BLOCK type=kotlin.Int origin=POSTFIX_INCR
-            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Int [val]
-              CALL 'public final fun <get-eagerCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Int [val]
+              CALL 'public final fun <get-eagerFunCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=POSTFIX_INCR
                 ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
-            CALL 'public final fun <set-eagerCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=POSTFIX_INCR
+            CALL 'public final fun <set-eagerFunCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=POSTFIX_INCR
               ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
               ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
-                ARG <this>: GET_VAR 'val tmp_0: kotlin.Int declared in <root>.TestModule.eager' type=kotlin.Int origin=null
-            GET_VAR 'val tmp_0: kotlin.Int declared in <root>.TestModule.eager' type=kotlin.Int origin=null
-        RETURN type=kotlin.Nothing from='public final fun eager (): <root>.Eager declared in <root>.TestModule'
-          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Eager' type=<root>.Eager origin=null
-    FUN name:lazy visibility:public modality:FINAL returnType:<root>.Lazy
+                ARG <this>: GET_VAR 'val tmp_2: kotlin.Int declared in <root>.TestModule.eagerFun' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_2: kotlin.Int declared in <root>.TestModule.eagerFun' type=kotlin.Int origin=null
+        RETURN type=kotlin.Nothing from='public final fun eagerFun (): <root>.EagerFromFun declared in <root>.TestModule'
+          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.EagerFromFun' type=<root>.EagerFromFun origin=null
+    FUN name:lazyFun visibility:public modality:FINAL returnType:<root>.LazyFromFun
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestModule
       annotations:
         Single(binds = <null>, createdAtStart = <null>)
       BLOCK_BODY
         TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
           BLOCK type=kotlin.Int origin=POSTFIX_INCR
-            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int [val]
-              CALL 'public final fun <get-lazyCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=POSTFIX_INCR
+            VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.Int [val]
+              CALL 'public final fun <get-lazyFunCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=POSTFIX_INCR
                 ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
-            CALL 'public final fun <set-lazyCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=POSTFIX_INCR
+            CALL 'public final fun <set-lazyFunCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=POSTFIX_INCR
               ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
               ARG <set-?>: CALL 'public final fun inc (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=POSTFIX_INCR
-                ARG <this>: GET_VAR 'val tmp_1: kotlin.Int declared in <root>.TestModule.lazy' type=kotlin.Int origin=null
-            GET_VAR 'val tmp_1: kotlin.Int declared in <root>.TestModule.lazy' type=kotlin.Int origin=null
-        RETURN type=kotlin.Nothing from='public final fun lazy (): <root>.Lazy declared in <root>.TestModule'
-          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Lazy' type=<root>.Lazy origin=null
+                ARG <this>: GET_VAR 'val tmp_3: kotlin.Int declared in <root>.TestModule.lazyFun' type=kotlin.Int origin=null
+            GET_VAR 'val tmp_3: kotlin.Int declared in <root>.TestModule.lazyFun' type=kotlin.Int origin=null
+        RETURN type=kotlin.Nothing from='public final fun lazyFun (): <root>.LazyFromFun declared in <root>.TestModule'
+          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.LazyFromFun' type=<root>.LazyFromFun origin=null
   CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Counter
-    PROPERTY name:eagerCtor visibility:public modality:FINAL [var]
-      FIELD PROPERTY_BACKING_FIELD name:eagerCtor type:kotlin.Int visibility:private
+    PROPERTY name:eagerClassCtor visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:eagerClassCtor type:kotlin.Int visibility:private
         EXPRESSION_BODY
           CONST Int type=kotlin.Int value=0
-      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-eagerCtor> visibility:public modality:FINAL returnType:kotlin.Int
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-eagerClassCtor> visibility:public modality:FINAL returnType:kotlin.Int
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
-        correspondingProperty: PROPERTY name:eagerCtor visibility:public modality:FINAL [var]
+        correspondingProperty: PROPERTY name:eagerClassCtor visibility:public modality:FINAL [var]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-eagerCtor> (): kotlin.Int declared in <root>.Counter'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:eagerCtor type:kotlin.Int visibility:private' type=kotlin.Int origin=null
-              receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<get-eagerCtor>' type=<root>.Counter origin=null
-      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-eagerCtor> visibility:public modality:FINAL returnType:kotlin.Unit
+          RETURN type=kotlin.Nothing from='public final fun <get-eagerClassCtor> (): kotlin.Int declared in <root>.Counter'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:eagerClassCtor type:kotlin.Int visibility:private' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<get-eagerClassCtor>' type=<root>.Counter origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-eagerClassCtor> visibility:public modality:FINAL returnType:kotlin.Unit
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
         VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
-        correspondingProperty: PROPERTY name:eagerCtor visibility:public modality:FINAL [var]
+        correspondingProperty: PROPERTY name:eagerClassCtor visibility:public modality:FINAL [var]
         BLOCK_BODY
-          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:eagerCtor type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
-            receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<set-eagerCtor>' type=<root>.Counter origin=null
-            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.Counter.<set-eagerCtor>' type=kotlin.Int origin=null
-    PROPERTY name:lazyCtor visibility:public modality:FINAL [var]
-      FIELD PROPERTY_BACKING_FIELD name:lazyCtor type:kotlin.Int visibility:private
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:eagerClassCtor type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<set-eagerClassCtor>' type=<root>.Counter origin=null
+            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.Counter.<set-eagerClassCtor>' type=kotlin.Int origin=null
+    PROPERTY name:lazyClassCtor visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:lazyClassCtor type:kotlin.Int visibility:private
         EXPRESSION_BODY
           CONST Int type=kotlin.Int value=0
-      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-lazyCtor> visibility:public modality:FINAL returnType:kotlin.Int
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-lazyClassCtor> visibility:public modality:FINAL returnType:kotlin.Int
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
-        correspondingProperty: PROPERTY name:lazyCtor visibility:public modality:FINAL [var]
+        correspondingProperty: PROPERTY name:lazyClassCtor visibility:public modality:FINAL [var]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-lazyCtor> (): kotlin.Int declared in <root>.Counter'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:lazyCtor type:kotlin.Int visibility:private' type=kotlin.Int origin=null
-              receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<get-lazyCtor>' type=<root>.Counter origin=null
-      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-lazyCtor> visibility:public modality:FINAL returnType:kotlin.Unit
+          RETURN type=kotlin.Nothing from='public final fun <get-lazyClassCtor> (): kotlin.Int declared in <root>.Counter'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:lazyClassCtor type:kotlin.Int visibility:private' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<get-lazyClassCtor>' type=<root>.Counter origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-lazyClassCtor> visibility:public modality:FINAL returnType:kotlin.Unit
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
         VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
-        correspondingProperty: PROPERTY name:lazyCtor visibility:public modality:FINAL [var]
+        correspondingProperty: PROPERTY name:lazyClassCtor visibility:public modality:FINAL [var]
         BLOCK_BODY
-          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:lazyCtor type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
-            receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<set-lazyCtor>' type=<root>.Counter origin=null
-            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.Counter.<set-lazyCtor>' type=kotlin.Int origin=null
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:lazyClassCtor type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<set-lazyClassCtor>' type=<root>.Counter origin=null
+            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.Counter.<set-lazyClassCtor>' type=kotlin.Int origin=null
+    PROPERTY name:eagerFunCtor visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:eagerFunCtor type:kotlin.Int visibility:private
+        EXPRESSION_BODY
+          CONST Int type=kotlin.Int value=0
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-eagerFunCtor> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
+        correspondingProperty: PROPERTY name:eagerFunCtor visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-eagerFunCtor> (): kotlin.Int declared in <root>.Counter'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:eagerFunCtor type:kotlin.Int visibility:private' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<get-eagerFunCtor>' type=<root>.Counter origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-eagerFunCtor> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
+        correspondingProperty: PROPERTY name:eagerFunCtor visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:eagerFunCtor type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<set-eagerFunCtor>' type=<root>.Counter origin=null
+            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.Counter.<set-eagerFunCtor>' type=kotlin.Int origin=null
+    PROPERTY name:lazyFunCtor visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:lazyFunCtor type:kotlin.Int visibility:private
+        EXPRESSION_BODY
+          CONST Int type=kotlin.Int value=0
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-lazyFunCtor> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
+        correspondingProperty: PROPERTY name:lazyFunCtor visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-lazyFunCtor> (): kotlin.Int declared in <root>.Counter'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:lazyFunCtor type:kotlin.Int visibility:private' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<get-lazyFunCtor>' type=<root>.Counter origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-lazyFunCtor> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
+        correspondingProperty: PROPERTY name:lazyFunCtor visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:lazyFunCtor type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.<set-lazyFunCtor>' type=<root>.Counter origin=null
+            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.Counter.<set-lazyFunCtor>' type=kotlin.Int origin=null
     CONSTRUCTOR visibility:private returnType:<root>.Counter [primary]
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
@@ -152,10 +268,16 @@ FILE fqName:<root> fileName:/test.kt
     FUN name:reset visibility:public modality:FINAL returnType:kotlin.Unit
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Counter
       BLOCK_BODY
-        CALL 'public final fun <set-eagerCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=EQ
+        CALL 'public final fun <set-eagerClassCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=EQ
           ARG <this>: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.reset' type=<root>.Counter origin=IMPLICIT_ARGUMENT
           ARG <set-?>: CONST Int type=kotlin.Int value=0
-        CALL 'public final fun <set-lazyCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=EQ
+        CALL 'public final fun <set-lazyClassCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=EQ
+          ARG <this>: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.reset' type=<root>.Counter origin=IMPLICIT_ARGUMENT
+          ARG <set-?>: CONST Int type=kotlin.Int value=0
+        CALL 'public final fun <set-eagerFunCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=EQ
+          ARG <this>: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.reset' type=<root>.Counter origin=IMPLICIT_ARGUMENT
+          ARG <set-?>: CONST Int type=kotlin.Int value=0
+        CALL 'public final fun <set-lazyFunCtor> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.Counter' type=kotlin.Unit origin=EQ
           ARG <this>: GET_VAR '<this>: <root>.Counter declared in <root>.Counter.reset' type=<root>.Counter origin=IMPLICIT_ARGUMENT
           ARG <set-?>: CONST Int type=kotlin.Int value=0
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
@@ -179,65 +301,111 @@ FILE fqName:<root> fileName:/test.kt
         BRANCH
           if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
             ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-              ARG arg0: CALL 'public final fun <get-eagerCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg0: CALL 'public final fun <get-eagerClassCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
                 ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
               ARG arg1: CONST Int type=kotlin.Int value=1
           then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
             STRING_CONCATENATION type=kotlin.String
-              CONST String type=kotlin.String value="FAIL: @Single(createdAtStart=true) fun not eagerly initialized (eagerCtor="
-              CALL 'public final fun <get-eagerCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value="FAIL: @Singleton(createdAtStart=true) class not eager (eagerClassCtor="
+              CALL 'public final fun <get-eagerClassCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
                 ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
               CONST String type=kotlin.String value=")"
       WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
             ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-              ARG arg0: CALL 'public final fun <get-lazyCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+              ARG arg0: CALL 'public final fun <get-eagerFunCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: @Single(createdAtStart=true) fun not eager (eagerFunCtor="
+              CALL 'public final fun <get-eagerFunCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+              CONST String type=kotlin.String value=")"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-lazyClassCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
                 ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
               ARG arg1: CONST Int type=kotlin.Int value=0
           then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
             STRING_CONCATENATION type=kotlin.String
-              CONST String type=kotlin.String value="FAIL: lazy @Single fun was eagerly initialized (lazyCtor="
-              CALL 'public final fun <get-lazyCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+              CONST String type=kotlin.String value="FAIL: lazy class eagerly initialized (lazyClassCtor="
+              CALL 'public final fun <get-lazyClassCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+              CONST String type=kotlin.String value=")"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun <get-lazyFunCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+              ARG arg1: CONST Int type=kotlin.Int value=0
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: lazy fun eagerly initialized (lazyFunCtor="
+              CALL 'public final fun <get-lazyFunCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
                 ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
               CONST String type=kotlin.String value=")"
       VAR name:koin type:org.koin.core.Koin [val]
         CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
           ARG <this>: GET_VAR 'val app: org.koin.core.KoinApplication declared in <root>.box' type=org.koin.core.KoinApplication origin=null
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.Lazy origin=null
-          TYPE_ARG T: <root>.Lazy
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.LazyClass origin=null
+          TYPE_ARG T: <root>.LazyClass
           ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
-      WHEN type=kotlin.Unit origin=IF
-        BRANCH
-          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-              ARG arg0: CALL 'public final fun <get-lazyCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
-                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
-              ARG arg1: CONST Int type=kotlin.Int value=1
-          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
-            STRING_CONCATENATION type=kotlin.String
-              CONST String type=kotlin.String value="FAIL: lazy missing after get<>() (lazyCtor="
-              CALL 'public final fun <get-lazyCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
-                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
-              CONST String type=kotlin.String value=")"
       TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
-        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.Eager origin=null
-          TYPE_ARG T: <root>.Eager
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.LazyFromFun origin=null
+          TYPE_ARG T: <root>.LazyFromFun
           ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
       WHEN type=kotlin.Unit origin=IF
         BRANCH
-          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-              ARG arg0: CALL 'public final fun <get-eagerCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
-                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
-              ARG arg1: CONST Int type=kotlin.Int value=1
+          if: WHEN type=kotlin.Boolean origin=OROR
+            BRANCH
+              if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                  ARG arg0: CALL 'public final fun <get-lazyClassCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+                    ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+                  ARG arg1: CONST Int type=kotlin.Int value=1
+              then: CONST Boolean type=kotlin.Boolean value=true
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                  ARG arg0: CALL 'public final fun <get-lazyFunCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+                    ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+                  ARG arg1: CONST Int type=kotlin.Int value=1
           then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
-            STRING_CONCATENATION type=kotlin.String
-              CONST String type=kotlin.String value="FAIL: eager re-instantiated on get<>() (eagerCtor="
-              CALL 'public final fun <get-eagerCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
-                ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
-              CONST String type=kotlin.String value=")"
+            CONST String type=kotlin.String value="FAIL: lazy defs missing after get<>()"
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.EagerClass origin=null
+          TYPE_ARG T: <root>.EagerClass
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.EagerFromFun origin=null
+          TYPE_ARG T: <root>.EagerFromFun
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: WHEN type=kotlin.Boolean origin=OROR
+            BRANCH
+              if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                  ARG arg0: CALL 'public final fun <get-eagerClassCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+                    ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+                  ARG arg1: CONST Int type=kotlin.Int value=1
+              then: CONST Boolean type=kotlin.Boolean value=true
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                  ARG arg0: CALL 'public final fun <get-eagerFunCtor> (): kotlin.Int declared in <root>.Counter' type=kotlin.Int origin=GET_PROPERTY
+                    ARG <this>: GET_OBJECT 'CLASS OBJECT name:Counter modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.Counter
+                  ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: eager def re-instantiated on get<>()"
       RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
         CONST String type=kotlin.String value="OK"
 FILE fqName:<root> fileName:/testModuleModule.kt
@@ -251,42 +419,67 @@ FILE fqName:<root> fileName:/testModuleModule.kt
               VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
               BLOCK_BODY
                 CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
-                  TYPE_ARG T: <root>.Eager
+                  TYPE_ARG T: <root>.EagerClass
                   ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
-                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:Eager modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Eager>
+                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:EagerClass modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.EagerClass>
                   ARG qualifier: CONST Null type=kotlin.Nothing? value=null
-                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.Eager> origin=LAMBDA
-                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.Eager
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.EagerClass> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.EagerClass
                       VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
                       VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
                       BLOCK_BODY
-                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.Eager declared in <root>.module.<anonymous>'
-                          CALL 'public final fun eager (): <root>.Eager declared in <root>.TestModule' type=<root>.Eager origin=null
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.EagerClass declared in <root>.module.<anonymous>'
+                          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.EagerClass' type=<root>.EagerClass origin=null
+                  ARG createdAtStart: CONST Boolean type=kotlin.Boolean value=true
+                CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                  TYPE_ARG T: <root>.LazyClass
+                  ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:LazyClass modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.LazyClass>
+                  ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.LazyClass> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.LazyClass
+                      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                      VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.LazyClass declared in <root>.module.<anonymous>'
+                          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.LazyClass' type=<root>.LazyClass origin=null
+                CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                  TYPE_ARG T: <root>.EagerFromFun
+                  ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:EagerFromFun modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.EagerFromFun>
+                  ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.EagerFromFun> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.EagerFromFun
+                      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                      VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.EagerFromFun declared in <root>.module.<anonymous>'
+                          CALL 'public final fun eagerFun (): <root>.EagerFromFun declared in <root>.TestModule' type=<root>.EagerFromFun origin=null
                             ARG <this>: GET_VAR '<this>: <root>.TestModule declared in <root>.module' type=<root>.TestModule origin=null
                   ARG createdAtStart: CONST Boolean type=kotlin.Boolean value=true
                 CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
-                  TYPE_ARG T: <root>.Lazy
+                  TYPE_ARG T: <root>.LazyFromFun
                   ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
-                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:Lazy modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Lazy>
+                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:LazyFromFun modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.LazyFromFun>
                   ARG qualifier: CONST Null type=kotlin.Nothing? value=null
-                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.Lazy> origin=LAMBDA
-                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.Lazy
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.LazyFromFun> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.LazyFromFun
                       VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
                       VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
                       BLOCK_BODY
-                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.Lazy declared in <root>.module.<anonymous>'
-                          CALL 'public final fun lazy (): <root>.Lazy declared in <root>.TestModule' type=<root>.Lazy origin=null
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.LazyFromFun declared in <root>.module.<anonymous>'
+                          CALL 'public final fun lazyFun (): <root>.LazyFromFun declared in <root>.TestModule' type=<root>.LazyFromFun origin=null
                             ARG <this>: GET_VAR '<this>: <root>.TestModule declared in <root>.module' type=<root>.TestModule origin=null
 FILE fqName:org.koin.plugin.hints fileName:org/koin/plugin/hints/testModuleModule.kt
-  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_testModule__eager visibility:public modality:FINAL returnType:kotlin.Unit
-    VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Eager
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_testModule__eagerFun visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.EagerFromFun
     annotations:
       Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
     BLOCK_BODY
       CALL 'public final fun error (message: kotlin.Any): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
         ARG message: CONST String type=kotlin.String value="Stub!"
-  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_testModule__lazy visibility:public modality:FINAL returnType:kotlin.Unit
-    VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.Lazy
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:moduledef_testModule__lazyFun visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] kind:Regular name:contributed index:0 type:<root>.LazyFromFun
     annotations:
       Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
     BLOCK_BODY

--- a/koin-compiler-plugin/testData/box/annotations/single_fun_created_at_start.fir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/single_fun_created_at_start.fir.txt
@@ -1,12 +1,12 @@
 FILE: test.kt
-    public final class Eager : R|kotlin/Any| {
-        public constructor(): R|Eager| {
+    public final class EagerFromFun : R|kotlin/Any| {
+        public constructor(): R|EagerFromFun| {
             super<R|kotlin/Any|>()
         }
 
     }
-    public final class Lazy : R|kotlin/Any| {
-        public constructor(): R|Lazy| {
+    public final class LazyFromFun : R|kotlin/Any| {
+        public constructor(): R|LazyFromFun| {
             super<R|kotlin/Any|>()
         }
 
@@ -16,43 +16,83 @@ FILE: test.kt
             super<R|kotlin/Any|>()
         }
 
-        public final var eagerCtor: R|kotlin/Int| = Int(0)
+        public final var eagerClassCtor: R|kotlin/Int| = Int(0)
             public get(): R|kotlin/Int|
             public set(value: R|kotlin/Int|): R|kotlin/Unit|
 
-        public final var lazyCtor: R|kotlin/Int| = Int(0)
+        public final var lazyClassCtor: R|kotlin/Int| = Int(0)
+            public get(): R|kotlin/Int|
+            public set(value: R|kotlin/Int|): R|kotlin/Unit|
+
+        public final var eagerFunCtor: R|kotlin/Int| = Int(0)
+            public get(): R|kotlin/Int|
+            public set(value: R|kotlin/Int|): R|kotlin/Unit|
+
+        public final var lazyFunCtor: R|kotlin/Int| = Int(0)
             public get(): R|kotlin/Int|
             public set(value: R|kotlin/Int|): R|kotlin/Unit|
 
         public final fun reset(): R|kotlin/Unit| {
-            this@R|/Counter|.R|/Counter.eagerCtor| = Int(0)
-            this@R|/Counter|.R|/Counter.lazyCtor| = Int(0)
+            this@R|/Counter|.R|/Counter.eagerClassCtor| = Int(0)
+            this@R|/Counter|.R|/Counter.lazyClassCtor| = Int(0)
+            this@R|/Counter|.R|/Counter.eagerFunCtor| = Int(0)
+            this@R|/Counter|.R|/Counter.lazyFunCtor| = Int(0)
         }
 
     }
-    @R|org/koin/core/annotation/Module|() public final class TestModule : R|kotlin/Any| {
+    @R|org/koin/core/annotation/Singleton|(createdAtStart = Boolean(true)) public final class EagerClass : R|kotlin/Any| {
+        public constructor(): R|EagerClass| {
+            super<R|kotlin/Any|>()
+        }
+
+        init {
+             {
+                lval <unary>: R|kotlin/Int| = Q|Counter|.R|/Counter.eagerClassCtor|
+                Q|Counter|.R|/Counter.eagerClassCtor| = R|<local>/<unary>|.R|kotlin/Int.inc|()
+                R|<local>/<unary>|
+            }
+
+        }
+
+    }
+    @R|org/koin/core/annotation/Singleton|() public final class LazyClass : R|kotlin/Any| {
+        public constructor(): R|LazyClass| {
+            super<R|kotlin/Any|>()
+        }
+
+        init {
+             {
+                lval <unary>: R|kotlin/Int| = Q|Counter|.R|/Counter.lazyClassCtor|
+                Q|Counter|.R|/Counter.lazyClassCtor| = R|<local>/<unary>|.R|kotlin/Int.inc|()
+                R|<local>/<unary>|
+            }
+
+        }
+
+    }
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|() public final class TestModule : R|kotlin/Any| {
         public constructor(): R|TestModule| {
             super<R|kotlin/Any|>()
         }
 
-        @R|org/koin/core/annotation/Single|(createdAtStart = Boolean(true)) public final fun eager(): R|Eager| {
+        @R|org/koin/core/annotation/Single|(createdAtStart = Boolean(true)) public final fun eagerFun(): R|EagerFromFun| {
              {
-                lval <unary>: R|kotlin/Int| = Q|Counter|.R|/Counter.eagerCtor|
-                Q|Counter|.R|/Counter.eagerCtor| = R|<local>/<unary>|.R|kotlin/Int.inc|()
+                lval <unary>: R|kotlin/Int| = Q|Counter|.R|/Counter.eagerFunCtor|
+                Q|Counter|.R|/Counter.eagerFunCtor| = R|<local>/<unary>|.R|kotlin/Int.inc|()
                 R|<local>/<unary>|
             }
 
-            ^eager R|/Eager.Eager|()
+            ^eagerFun R|/EagerFromFun.EagerFromFun|()
         }
 
-        @R|org/koin/core/annotation/Single|() public final fun lazy(): R|Lazy| {
+        @R|org/koin/core/annotation/Single|() public final fun lazyFun(): R|LazyFromFun| {
              {
-                lval <unary>: R|kotlin/Int| = Q|Counter|.R|/Counter.lazyCtor|
-                Q|Counter|.R|/Counter.lazyCtor| = R|<local>/<unary>|.R|kotlin/Int.inc|()
+                lval <unary>: R|kotlin/Int| = Q|Counter|.R|/Counter.lazyFunCtor|
+                Q|Counter|.R|/Counter.lazyFunCtor| = R|<local>/<unary>|.R|kotlin/Int.inc|()
                 R|<local>/<unary>|
             }
 
-            ^lazy R|/Lazy.Lazy|()
+            ^lazyFun R|/LazyFromFun.LazyFromFun|()
         }
 
     }
@@ -64,29 +104,43 @@ FILE: test.kt
         )
         R|<local>/app|.R|org/koin/core/KoinApplication.createEagerInstances|()
         when () {
-            !=(Q|Counter|.R|/Counter.eagerCtor|, Int(1)) ->  {
-                ^box <strcat>(String(FAIL: @Single(createdAtStart=true) fun not eagerly initialized (eagerCtor=), Q|Counter|.R|/Counter.eagerCtor|, String()))
+            !=(Q|Counter|.R|/Counter.eagerClassCtor|, Int(1)) ->  {
+                ^box <strcat>(String(FAIL: @Singleton(createdAtStart=true) class not eager (eagerClassCtor=), Q|Counter|.R|/Counter.eagerClassCtor|, String()))
             }
         }
 
         when () {
-            !=(Q|Counter|.R|/Counter.lazyCtor|, Int(0)) ->  {
-                ^box <strcat>(String(FAIL: lazy @Single fun was eagerly initialized (lazyCtor=), Q|Counter|.R|/Counter.lazyCtor|, String()))
+            !=(Q|Counter|.R|/Counter.eagerFunCtor|, Int(1)) ->  {
+                ^box <strcat>(String(FAIL: @Single(createdAtStart=true) fun not eager (eagerFunCtor=), Q|Counter|.R|/Counter.eagerFunCtor|, String()))
+            }
+        }
+
+        when () {
+            !=(Q|Counter|.R|/Counter.lazyClassCtor|, Int(0)) ->  {
+                ^box <strcat>(String(FAIL: lazy class eagerly initialized (lazyClassCtor=), Q|Counter|.R|/Counter.lazyClassCtor|, String()))
+            }
+        }
+
+        when () {
+            !=(Q|Counter|.R|/Counter.lazyFunCtor|, Int(0)) ->  {
+                ^box <strcat>(String(FAIL: lazy fun eagerly initialized (lazyFunCtor=), Q|Counter|.R|/Counter.lazyFunCtor|, String()))
             }
         }
 
         lval koin: R|org/koin/core/Koin| = R|<local>/app|.R|org/koin/core/KoinApplication.koin|
-        R|<local>/koin|.R|org/koin/core/Koin.get|<R|Lazy|>()
+        R|<local>/koin|.R|org/koin/core/Koin.get|<R|LazyClass|>()
+        R|<local>/koin|.R|org/koin/core/Koin.get|<R|LazyFromFun|>()
         when () {
-            !=(Q|Counter|.R|/Counter.lazyCtor|, Int(1)) ->  {
-                ^box <strcat>(String(FAIL: lazy missing after get<>() (lazyCtor=), Q|Counter|.R|/Counter.lazyCtor|, String()))
+            !=(Q|Counter|.R|/Counter.lazyClassCtor|, Int(1)) || !=(Q|Counter|.R|/Counter.lazyFunCtor|, Int(1)) ->  {
+                ^box String(FAIL: lazy defs missing after get<>())
             }
         }
 
-        R|<local>/koin|.R|org/koin/core/Koin.get|<R|Eager|>()
+        R|<local>/koin|.R|org/koin/core/Koin.get|<R|EagerClass|>()
+        R|<local>/koin|.R|org/koin/core/Koin.get|<R|EagerFromFun|>()
         when () {
-            !=(Q|Counter|.R|/Counter.eagerCtor|, Int(1)) ->  {
-                ^box <strcat>(String(FAIL: eager re-instantiated on get<>() (eagerCtor=), Q|Counter|.R|/Counter.eagerCtor|, String()))
+            !=(Q|Counter|.R|/Counter.eagerClassCtor|, Int(1)) || !=(Q|Counter|.R|/Counter.eagerFunCtor|, Int(1)) ->  {
+                ^box String(FAIL: eager def re-instantiated on get<>())
             }
         }
 
@@ -97,5 +151,5 @@ FILE: /testModuleModule.kt
 FILE: org/koin/plugin/hints/testModuleModule.kt
     package org.koin.plugin.hints
 
-    @R|kotlin/Deprecated|(message = String(Koin compiler plugin internal hint function), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun moduledef_testModule__eager(contributed: R|Eager|): R|kotlin/Unit|
-    @R|kotlin/Deprecated|(message = String(Koin compiler plugin internal hint function), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun moduledef_testModule__lazy(contributed: R|Lazy|): R|kotlin/Unit|
+    @R|kotlin/Deprecated|(message = String(Koin compiler plugin internal hint function), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun moduledef_testModule__eagerFun(contributed: R|EagerFromFun|): R|kotlin/Unit|
+    @R|kotlin/Deprecated|(message = String(Koin compiler plugin internal hint function), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun moduledef_testModule__lazyFun(contributed: R|LazyFromFun|): R|kotlin/Unit|

--- a/koin-compiler-plugin/testData/box/annotations/single_fun_created_at_start.kt
+++ b/koin-compiler-plugin/testData/box/annotations/single_fun_created_at_start.kt
@@ -1,36 +1,54 @@
 // FILE: test.kt
-// Regression test for KTZ-4152 / GH koin#2425:
-// `@Single(createdAtStart = true)` on a DEFINITION FUNCTION inside a @Module was
-// silently ignored. The module-level fix (KTZ-4048) covered `@Module(createdAtStart)`
-// and `@Singleton class`, but `buildFunctionDefinitionCall` never propagated the
-// per-definition flag, so the generated `buildSingle(...)` fell back to the default
-// (false) and the eager side effect was lost.
+// Regression test for KTZ-4152 / GH koin#2425 (and guards the sibling paths):
+// per-definition `createdAtStart = true` must be honored independently of the
+// module-level flag.
+//
+// `@Module(createdAtStart)` and `@Singleton class` were addressed by KTZ-4048, but
+// `buildFunctionDefinitionCall` — `@Single`/`@Singleton` definition FUNCTIONS inside a
+// @Module — never propagated the per-definition flag, so the generated `buildSingle(...)`
+// fell back to the default (false) and the eager side effect was silently lost.
 //
 // The module here deliberately has NO `@Module(createdAtStart = true)` — otherwise the
-// module-level flag would eagerly init everything and mask the per-definition defect.
-//
-// Verification: only `eager()` is annotated `createdAtStart = true`, so after
-// `createEagerInstances()` exactly the eager counter must be 1 and the lazy one 0.
+// module-level flag would eagerly init everything and mask any per-definition defect.
+// It exercises BOTH definition shapes so the class path and the function path are each
+// verified independently:
+//   - eager CLASS   (@Singleton(createdAtStart = true) class)  -> buildClassDefinitionCall
+//   - eager FUNCTION (@Single(createdAtStart = true) fun)       -> buildFunctionDefinitionCall
+// with lazy counterparts of each.
 import org.koin.dsl.koinApplication
+import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
+import org.koin.core.annotation.Singleton
 
-class Eager
-class Lazy
+class EagerFromFun
+class LazyFromFun
 
 object Counter {
-    var eagerCtor = 0
-    var lazyCtor = 0
-    fun reset() { eagerCtor = 0; lazyCtor = 0 }
+    var eagerClassCtor = 0
+    var lazyClassCtor = 0
+    var eagerFunCtor = 0
+    var lazyFunCtor = 0
+    fun reset() { eagerClassCtor = 0; lazyClassCtor = 0; eagerFunCtor = 0; lazyFunCtor = 0 }
 }
 
+@Singleton(createdAtStart = true)
+class EagerClass { init { Counter.eagerClassCtor++ } }
+
+@Singleton
+class LazyClass { init { Counter.lazyClassCtor++ } }
+
+// @ComponentScan picks up the top-level @Singleton classes; the member @Single
+// functions are this module's own definitions. NOTE: no @Module(createdAtStart) —
+// each definition's own flag must stand on its own.
 @Module
+@ComponentScan
 class TestModule {
     @Single(createdAtStart = true)
-    fun eager(): Eager { Counter.eagerCtor++; return Eager() }
+    fun eagerFun(): EagerFromFun { Counter.eagerFunCtor++; return EagerFromFun() }
 
     @Single
-    fun lazy(): Lazy { Counter.lazyCtor++; return Lazy() }
+    fun lazyFun(): LazyFromFun { Counter.lazyFunCtor++; return LazyFromFun() }
 }
 
 fun box(): String {
@@ -39,16 +57,19 @@ fun box(): String {
     val app = koinApplication { modules(TestModule().module()) }
     app.createEagerInstances()
 
-    if (Counter.eagerCtor != 1) return "FAIL: @Single(createdAtStart=true) fun not eagerly initialized (eagerCtor=${Counter.eagerCtor})"
-    if (Counter.lazyCtor != 0) return "FAIL: lazy @Single fun was eagerly initialized (lazyCtor=${Counter.lazyCtor})"
+    // Eager class + eager fun must be constructed at createEagerInstances(); lazies must not.
+    if (Counter.eagerClassCtor != 1) return "FAIL: @Singleton(createdAtStart=true) class not eager (eagerClassCtor=${Counter.eagerClassCtor})"
+    if (Counter.eagerFunCtor != 1) return "FAIL: @Single(createdAtStart=true) fun not eager (eagerFunCtor=${Counter.eagerFunCtor})"
+    if (Counter.lazyClassCtor != 0) return "FAIL: lazy class eagerly initialized (lazyClassCtor=${Counter.lazyClassCtor})"
+    if (Counter.lazyFunCtor != 0) return "FAIL: lazy fun eagerly initialized (lazyFunCtor=${Counter.lazyFunCtor})"
 
     val koin = app.koin
-    koin.get<Lazy>()
-    if (Counter.lazyCtor != 1) return "FAIL: lazy missing after get<>() (lazyCtor=${Counter.lazyCtor})"
+    koin.get<LazyClass>(); koin.get<LazyFromFun>()
+    if (Counter.lazyClassCtor != 1 || Counter.lazyFunCtor != 1) return "FAIL: lazy defs missing after get<>()"
 
-    // Eager definition must still be a singleton — not re-created on get<>().
-    koin.get<Eager>()
-    if (Counter.eagerCtor != 1) return "FAIL: eager re-instantiated on get<>() (eagerCtor=${Counter.eagerCtor})"
+    // Eager defs are singletons — not re-created on get<>().
+    koin.get<EagerClass>(); koin.get<EagerFromFun>()
+    if (Counter.eagerClassCtor != 1 || Counter.eagerFunCtor != 1) return "FAIL: eager def re-instantiated on get<>()"
 
     return "OK"
 }

--- a/playground-apps/app-annotations/core/database/src/main/kotlin/org/koin/sample/database/di/DatabaseModule.kt
+++ b/playground-apps/app-annotations/core/database/src/main/kotlin/org/koin/sample/database/di/DatabaseModule.kt
@@ -9,7 +9,9 @@ import org.koin.sample.database.AppDatabase
 @Module
 internal object DatabaseModule {
 
-    @Singleton
+    // createdAtStart: open the Room database eagerly at startKoin rather than on first
+    // injection (exercises per-definition createdAtStart on a @Singleton function — koin#2425).
+    @Singleton(createdAtStart = true)
     fun providesDatabase(context: Context): AppDatabase =
         Room.databaseBuilder(
             context,

--- a/playground-apps/app-kmp-klib/src/commonMain/kotlin/playground/App.kt
+++ b/playground-apps/app-kmp-klib/src/commonMain/kotlin/playground/App.kt
@@ -4,6 +4,7 @@ import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Factory
 import org.koin.core.annotation.InjectedParam
 import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
 
 // Same @InjectedParam target collected by two @ComponentScan modules — the case
 // that emitted the injectedparams_* hint twice and broke KLIB serialization
@@ -13,9 +14,16 @@ import org.koin.core.annotation.Module
 @Factory
 class Greeter(@InjectedParam val name: String)
 
+class EagerService
+
 @Module
 @ComponentScan
-class FirstModule
+class FirstModule {
+    // Per-definition createdAtStart on a @Single function — eager init at startKoin.
+    // Silently dropped before the fix (koin#2425); exercised here on the KLIB targets.
+    @Single(createdAtStart = true)
+    fun eager(): EagerService = EagerService()
+}
 
 @Module
 @ComponentScan


### PR DESCRIPTION
## Problem

`koin-compiler-plugin` silently ignored `createdAtStart = true` on `@Single` / `@Singleton` **definition functions** inside a `@Module`. The generated `buildSingle(...)` fell back to Kotlin's default-arg trampoline (`false`), so eager singletons were never created at `startKoin` — no compile error, no warning (koin#2425, koin#2415).

## Root cause

`createdAtStart` propagation existed in `buildClassDefinitionCall` and `buildTopLevelFunctionDefinitionCall`, but **`buildFunctionDefinitionCall`** (the `@Single`/`@Singleton` *function inside a @Module* path) never set it. The module-level fix (RC3.13, `@Module(createdAtStart)`) masked this in the existing test.

## Fix

Propagate `createdAtStart` to `buildSingle(...)` for SINGLE function definitions, mirroring the other two builders.

## Tests & samples

- **Box test `single_fun_created_at_start`** in a deliberately **non-eager** `@ComponentScan` module (so the module-level flag can't mask it), exercising **both** per-definition shapes: `@Singleton(createdAtStart=true) class` and `@Single(createdAtStart=true) fun`, each with a lazy counterpart. Verified **pre-fix FAIL / post-fix PASS**.
- **Sample apps:** `app-annotations` `DatabaseModule` (eager Room DB open) and `app-kmp-klib` (`@Single(createdAtStart=true)` exercised on iosArm64).

Full box suite green.

Fixes InsertKoinIO/koin#2425, InsertKoinIO/koin#2415

> Stacked on the merged compat/dedup/wasmJs fixes already in `1.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
