### PR TITLE
Report missing ComponentScan coverage for top-level providers

### DIFF
--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinDiagnostic.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinDiagnostic.kt
@@ -206,6 +206,21 @@ sealed class KoinDiagnostic(
     )
 
     /**
+     * KOIN-D008 — A top-level annotated definition exists locally, but no loaded @Module
+     * includes it via @ComponentScan, so same-module call sites would fail at runtime.
+     */
+    class UnclaimedTopLevelDefinition(
+        function: String,
+        returnType: String,
+    ) : KoinDiagnostic(
+        code = "KOIN-D008",
+        severity = Severity.ERROR,
+        message = "Top-level definition function is not covered by any local @ComponentScan: " +
+                "$function -> $returnType\n" +
+                "  Add @ComponentScan to a @Module that covers this function's package, or move the function inside a @Module class.",
+    )
+
+    /**
      * KOIN-W001 — A DSL module is not loaded at `startKoin`, so its definitions are unreachable.
      *
      * Warning, not error: a user mid-refactor commonly has a module defined but not yet wired

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/CallSiteValidator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/CallSiteValidator.kt
@@ -47,6 +47,7 @@ class CallSiteValidator(private val context: IrPluginContext) {
         annotationProcessor: KoinAnnotationProcessor?,
         dslHintGenerator: DslHintGenerator,
         injectedParamHints: InjectedParamHintGenerator? = null,
+        hasKoinEntryPoint: Boolean = false,
     ) {
         val hasFullGraph = assembledGraphTypes.isNotEmpty()
 
@@ -117,6 +118,22 @@ class CallSiteValidator(private val context: IrPluginContext) {
                     if (injectedParamHints != null) validateInjectedParamShapeAtCallSite(callSite, injectedParamHints)
                     continue
                 }
+            }
+
+            val unclaimedTopLevelDefinition = if (hasKoinEntryPoint) {
+                annotationProcessor?.findUnclaimedTopLevelDefinitionProvider(callSite.targetFqName)
+            } else {
+                null
+            }
+            if (unclaimedTopLevelDefinition != null) {
+                KoinPluginLogger.report(
+                    KoinDiagnostic.UnclaimedTopLevelDefinition(
+                        function = "${unclaimedTopLevelDefinition.irFunction.name.asString()}()",
+                        returnType = callSite.targetFqName,
+                    ),
+                    callSite.filePath, callSite.line, callSite.column
+                )
+                continue
             }
 
             // Not resolved locally

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinAnnotationProcessor.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinAnnotationProcessor.kt
@@ -175,6 +175,30 @@ class KoinAnnotationProcessor(
         }
     }
 
+    /**
+     * Find a local top-level definition function that provides [targetFqName] but is not
+     * included by any local @ComponentScan module. Such functions are valid cross-module
+     * exports, but in an entry-point module they would be silently absent from the runtime graph.
+     */
+    fun findUnclaimedTopLevelDefinitionProvider(targetFqName: String): DefinitionTopLevelFunction? {
+        if (definitionTopLevelFunctions.isEmpty()) return null
+
+        val claimedFunctions = moduleClasses
+            .asSequence()
+            .filter { it.hasComponentScan }
+            .flatMap { moduleClass ->
+                collectFromPackageIndex(
+                    index = topLevelFunctionsByPackage,
+                    scanPackages = moduleClass.effectiveScanPackages(),
+                ).asSequence()
+            }
+            .mapTo(hashSetOf()) { it.irFunction }
+
+        return definitionTopLevelFunctions.firstOrNull { definition ->
+            definition.irFunction !in claimedFunctions && definition.providesType(targetFqName)
+        }
+    }
+
     /** Get definitions from a dependency JAR module (for cross-module validation). */
     internal fun getDefinitionsForDependencyModule(moduleFqName: String): DependencyModuleResult {
         return collectDefinitionsFromDependencyModule(moduleFqName)
@@ -2212,6 +2236,11 @@ class KoinAnnotationProcessor(
         return scanPackages.ifEmpty {
             listOf(irClass.packageFqName?.asString() ?: "")
         }
+    }
+
+    private fun DefinitionTopLevelFunction.providesType(targetFqName: String): Boolean {
+        if (returnTypeClass.fqNameWhenAvailable?.asString() == targetFqName) return true
+        return bindings.any { it.fqNameWhenAvailable?.asString() == targetFqName }
     }
 
     /**

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinIrExtension.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinIrExtension.kt
@@ -123,7 +123,16 @@ class KoinIrExtension(
         // Unresolved call sites (when no full graph) generate call-site hints for deferred validation.
         if (safetyValidator != null && pendingCallSites.isNotEmpty()) {
             KoinPluginLogger.debug { "Phase 3.5: Validating ${pendingCallSites.size} call-site resolutions (graph types: ${safetyValidator.assembledGraphTypes.size})" }
-            callSiteValidator.validatePendingCallSites(moduleFragment, pendingCallSites, safetyValidator.assembledGraphTypes, dslDefinitions, annotationProcessor, dslHintGenerator, injectedParamHints)
+            callSiteValidator.validatePendingCallSites(
+                moduleFragment = moduleFragment,
+                callSites = pendingCallSites,
+                assembledGraphTypes = safetyValidator.assembledGraphTypes,
+                dslDefinitions = dslDefinitions,
+                annotationProcessor = annotationProcessor,
+                dslHintGenerator = dslHintGenerator,
+                injectedParamHints = injectedParamHints,
+                hasKoinEntryPoint = startKoinTransformer.hasKoinEntryPoint
+            )
         }
 
         // Phase 3.6: Validate call-site hints from dependency modules against known definitions

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinStartTransformer.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinStartTransformer.kt
@@ -120,6 +120,7 @@ class KoinStartTransformer(
         // Detect non-generic startKoin { } or koinApplication { } (entry point signal)
         if (fqNameStr == "org.koin.core.context.startKoin" ||
             fqNameStr == "org.koin.core.context.GlobalContext.startKoin" ||
+            fqNameStr == "org.koin.dsl.koinApplication" ||
             fqNameStr == "org.koin.core.KoinApplication.Companion.init") {
             hasKoinEntryPoint = true
         }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -557,6 +557,12 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     }
 
     @Test
+    @TestMetadata("single_function_concrete_type.kt")
+    public void testSingle_function_concrete_type() {
+      runTest("koin-compiler-plugin/testData/box/toplevel/single_function_concrete_type.kt");
+    }
+
+    @Test
     @TestMetadata("singleton_function.kt")
     public void testSingleton_function() {
       runTest("koin-compiler-plugin/testData/box/toplevel/singleton_function.kt");

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmDiagnosticTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmDiagnosticTestGenerated.java
@@ -157,4 +157,10 @@ public class JvmDiagnosticTestGenerated extends AbstractJvmDiagnosticTest {
   public void testStartkoin_missing() {
     runTest("koin-compiler-plugin/testData/diagnostics/startkoin_missing.kt");
   }
+
+  @Test
+  @TestMetadata("toplevel_function_without_component_scan.kt")
+  public void testToplevel_function_without_component_scan() {
+    runTest("koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.kt");
+  }
 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmDiagnosticTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmDiagnosticTestGenerated.java
@@ -163,4 +163,10 @@ public class JvmDiagnosticTestGenerated extends AbstractJvmDiagnosticTest {
   public void testToplevel_function_without_component_scan() {
     runTest("koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.kt");
   }
+
+  @Test
+  @TestMetadata("toplevel_function_without_component_scan_koin_application.kt")
+  public void testToplevel_function_without_component_scan_koin_application() {
+    runTest("koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan_koin_application.kt");
+  }
 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmErrorMessageTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmErrorMessageTestGenerated.java
@@ -163,4 +163,10 @@ public class JvmErrorMessageTestGenerated extends AbstractJvmErrorMessageTest {
   public void testToplevel_function_without_component_scan() {
     runTest("koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.kt");
   }
+
+  @Test
+  @TestMetadata("toplevel_function_without_component_scan_koin_application.kt")
+  public void testToplevel_function_without_component_scan_koin_application() {
+    runTest("koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan_koin_application.kt");
+  }
 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmErrorMessageTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmErrorMessageTestGenerated.java
@@ -157,4 +157,10 @@ public class JvmErrorMessageTestGenerated extends AbstractJvmErrorMessageTest {
   public void testStartkoin_missing() {
     runTest("koin-compiler-plugin/testData/diagnostics/startkoin_missing.kt");
   }
+
+  @Test
+  @TestMetadata("toplevel_function_without_component_scan.kt")
+  public void testToplevel_function_without_component_scan() {
+    runTest("koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.kt");
+  }
 }

--- a/koin-compiler-plugin/testData/box/toplevel/single_function_concrete_type.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/toplevel/single_function_concrete_type.fir.ir.txt
@@ -1,0 +1,130 @@
+FILE fqName:org.koin.plugin.hints fileName:/koin_hints_testpkg_TestModule.kt
+  FUN name:componentscanfunc_testpkg_TestModule_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:testpkg.JsonLike
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:testpkg fileName:/test.kt
+  CLASS CLASS name:JsonLike modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:testpkg.JsonLike
+    PROPERTY name:ignoreUnknownKeys visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:ignoreUnknownKeys type:kotlin.Boolean visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'ignoreUnknownKeys: kotlin.Boolean declared in testpkg.JsonLike.<init>' type=kotlin.Boolean origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-ignoreUnknownKeys> visibility:public modality:FINAL returnType:kotlin.Boolean
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:testpkg.JsonLike
+        correspondingProperty: PROPERTY name:ignoreUnknownKeys visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-ignoreUnknownKeys> (): kotlin.Boolean declared in testpkg.JsonLike'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:ignoreUnknownKeys type:kotlin.Boolean visibility:private [final]' type=kotlin.Boolean origin=null
+              receiver: GET_VAR '<this>: testpkg.JsonLike declared in testpkg.JsonLike.<get-ignoreUnknownKeys>' type=testpkg.JsonLike origin=null
+    CONSTRUCTOR visibility:public returnType:testpkg.JsonLike [primary]
+      VALUE_PARAMETER kind:Regular name:ignoreUnknownKeys index:0 type:kotlin.Boolean
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:JsonLike modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = ["testpkg"] type=kotlin.Array<out kotlin.String> varargElementType=kotlin.String)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:testpkg.TestModule
+    CONSTRUCTOR visibility:public returnType:testpkg.TestModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in testpkg.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: CALL 'public final fun module (<this>: testpkg.TestModule): org.koin.core.module.Module declared in testpkg' type=org.koin.core.module.Module origin=null
+                        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in testpkg.TestModule' type=testpkg.TestModule origin=null
+      VAR name:json1 type:testpkg.JsonLike [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=testpkg.JsonLike origin=null
+          TYPE_ARG T: testpkg.JsonLike
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in testpkg.box' type=org.koin.core.Koin origin=null
+      VAR name:json2 type:testpkg.JsonLike [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=testpkg.JsonLike origin=null
+          TYPE_ARG T: testpkg.JsonLike
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in testpkg.box' type=org.koin.core.Koin origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in testpkg'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: WHEN type=kotlin.Boolean origin=ANDAND
+              BRANCH
+                if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+                  ARG arg0: GET_VAR 'val json1: testpkg.JsonLike declared in testpkg.box' type=testpkg.JsonLike origin=null
+                  ARG arg1: GET_VAR 'val json2: testpkg.JsonLike declared in testpkg.box' type=testpkg.JsonLike origin=null
+                then: CALL 'public final fun <get-ignoreUnknownKeys> (): kotlin.Boolean declared in testpkg.JsonLike' type=kotlin.Boolean origin=GET_PROPERTY
+                  ARG <this>: GET_VAR 'val json1: testpkg.JsonLike declared in testpkg.box' type=testpkg.JsonLike origin=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CONST Boolean type=kotlin.Boolean value=false
+            then: BLOCK type=kotlin.String origin=null
+              CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: BLOCK type=kotlin.String origin=null
+              CONST String type=kotlin.String value="FAIL: top-level @Single function was not registered as singleton"
+  FUN name:json visibility:public modality:FINAL returnType:testpkg.JsonLike
+    annotations:
+      Single(binds = <null>, createdAtStart = <null>)
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun json (): testpkg.JsonLike declared in testpkg'
+        CONSTRUCTOR_CALL 'public constructor <init> (ignoreUnknownKeys: kotlin.Boolean) declared in testpkg.JsonLike' type=testpkg.JsonLike origin=null
+          ARG ignoreUnknownKeys: CONST Boolean type=kotlin.Boolean value=true
+FILE fqName:testpkg fileName:testpkg/testpkgTestModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:testpkg.TestModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: testpkg.TestModule): org.koin.core.module.Module declared in testpkg'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                  TYPE_ARG T: testpkg.JsonLike
+                  ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in testpkg.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:JsonLike modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<testpkg.JsonLike>
+                  ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, testpkg.JsonLike> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:testpkg.JsonLike
+                      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                      VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): testpkg.JsonLike declared in testpkg.module.<anonymous>'
+                          CALL 'public final fun json (): testpkg.JsonLike declared in testpkg' type=testpkg.JsonLike origin=null

--- a/koin-compiler-plugin/testData/box/toplevel/single_function_concrete_type.fir.txt
+++ b/koin-compiler-plugin/testData/box/toplevel/single_function_concrete_type.fir.txt
@@ -1,0 +1,42 @@
+FILE: test.kt
+    package testpkg
+
+    public final class JsonLike : R|kotlin/Any| {
+        public constructor(ignoreUnknownKeys: R|kotlin/Boolean|): R|testpkg/JsonLike| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val ignoreUnknownKeys: R|kotlin/Boolean| = R|<local>/ignoreUnknownKeys|
+            public get(): R|kotlin/Boolean|
+
+    }
+    @R|org/koin/core/annotation/Single|() public final fun json(): R|testpkg/JsonLike| {
+        ^json R|testpkg/JsonLike.JsonLike|(Boolean(true))
+    }
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|(value = vararg(String(testpkg))) public final class TestModule : R|kotlin/Any| {
+        public constructor(): R|testpkg/TestModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|testpkg/TestModule.TestModule|().R|testpkg/module|())
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval json1: R|testpkg/JsonLike| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|testpkg/JsonLike|>()
+        lval json2: R|testpkg/JsonLike| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|testpkg/JsonLike|>()
+        ^box when () {
+            ===(R|<local>/json1|, R|<local>/json2|) && R|<local>/json1|.R|testpkg/JsonLike.ignoreUnknownKeys| ->  {
+                String(OK)
+            }
+            else ->  {
+                String(FAIL: top-level @Single function was not registered as singleton)
+            }
+        }
+
+    }
+FILE: testpkg/testpkgTestModuleModule.kt
+    package testpkg
+
+    public final fun R|testpkg/TestModule|.module(): R|org/koin/core/module/Module|

--- a/koin-compiler-plugin/testData/box/toplevel/single_function_concrete_type.kt
+++ b/koin-compiler-plugin/testData/box/toplevel/single_function_concrete_type.kt
@@ -1,0 +1,31 @@
+// FILE: test.kt
+package testpkg
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+import org.koin.dsl.koinApplication
+
+class JsonLike(val ignoreUnknownKeys: Boolean)
+
+@Single
+fun json(): JsonLike = JsonLike(ignoreUnknownKeys = true)
+
+@Module
+@ComponentScan("testpkg")
+class TestModule
+
+fun box(): String {
+    val koin = koinApplication {
+        modules(TestModule().module())
+    }.koin
+
+    val json1 = koin.get<JsonLike>()
+    val json2 = koin.get<JsonLike>()
+
+    return if (json1 === json2 && json1.ignoreUnknownKeys) {
+        "OK"
+    } else {
+        "FAIL: top-level @Single function was not registered as singleton"
+    }
+}

--- a/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.errors.txt
+++ b/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.errors.txt
@@ -1,0 +1,2 @@
+[Koin][KOIN-D008] Top-level definition function is not covered by any local @ComponentScan: json() -> JsonLike
+  Add @ComponentScan to a @Module that covers this function's package, or move the function inside a @Module class.

--- a/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.fir.txt
@@ -1,0 +1,29 @@
+FILE: test.kt
+    public final class JsonLike : R|kotlin/Any| {
+        public constructor(): R|JsonLike| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|org/koin/core/annotation/Single|() public final fun json(): R|JsonLike| {
+        ^json R|/JsonLike.JsonLike|()
+    }
+    @R|org/koin/core/annotation/Module|() public final class TestModule : R|kotlin/Any| {
+        public constructor(): R|TestModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun main(): R|kotlin/Unit| {
+        lval app: R|org/koin/core/KoinApplication| = R|org/koin/core/context/startKoin|(<L> = startKoin@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/TestModule.TestModule|().R|/module|())
+        }
+        )
+        R|<local>/app|.R|org/koin/core/KoinApplication.koin|.R|org/koin/core/Koin.get|<R|JsonLike|>()
+    }
+FILE: /testModuleModule.kt
+    public final fun R|TestModule|.module(): R|org/koin/core/module/Module|
+FILE: org/koin/plugin/hints/_json_FunctionDefinition.kt
+    package org.koin.plugin.hints
+
+    @R|kotlin/Deprecated|(message = String(Koin compiler plugin internal hint function), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun definition_function_single(contributed: R|JsonLike|): R|kotlin/Unit|

--- a/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.kt
+++ b/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan.kt
@@ -1,0 +1,24 @@
+// RUN_PIPELINE_TILL: BACKEND
+// FILE: test.kt
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+class JsonLike
+
+@Single
+fun json(): JsonLike = JsonLike()
+
+@Module
+class TestModule
+
+fun main() {
+    val app = startKoin {
+        modules(TestModule().module())
+    }
+
+    app.koin.get<JsonLike>()
+}
+
+/* GENERATED_FIR_TAGS: classDeclaration, functionDeclaration, lambdaLiteral */

--- a/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan_koin_application.errors.txt
+++ b/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan_koin_application.errors.txt
@@ -1,0 +1,2 @@
+[Koin][KOIN-D008] Top-level definition function is not covered by any local @ComponentScan: json() -> JsonLike
+  Add @ComponentScan to a @Module that covers this function's package, or move the function inside a @Module class.

--- a/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan_koin_application.fir.txt
+++ b/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan_koin_application.fir.txt
@@ -1,0 +1,29 @@
+FILE: test.kt
+    public final class JsonLike : R|kotlin/Any| {
+        public constructor(): R|JsonLike| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|org/koin/core/annotation/Single|() public final fun json(): R|JsonLike| {
+        ^json R|/JsonLike.JsonLike|()
+    }
+    @R|org/koin/core/annotation/Module|() public final class TestModule : R|kotlin/Any| {
+        public constructor(): R|TestModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun main(): R|kotlin/Unit| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/TestModule.TestModule|().R|/module|())
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        R|<local>/koin|.R|org/koin/core/Koin.get|<R|JsonLike|>()
+    }
+FILE: /testModuleModule.kt
+    public final fun R|TestModule|.module(): R|org/koin/core/module/Module|
+FILE: org/koin/plugin/hints/_json_FunctionDefinition.kt
+    package org.koin.plugin.hints
+
+    @R|kotlin/Deprecated|(message = String(Koin compiler plugin internal hint function), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun definition_function_single(contributed: R|JsonLike|): R|kotlin/Unit|

--- a/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan_koin_application.kt
+++ b/koin-compiler-plugin/testData/diagnostics/toplevel_function_without_component_scan_koin_application.kt
@@ -1,0 +1,23 @@
+// RUN_PIPELINE_TILL: BACKEND
+// FILE: test.kt
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+import org.koin.dsl.koinApplication
+
+class JsonLike
+
+@Single
+fun json(): JsonLike = JsonLike()
+
+@Module
+class TestModule
+
+fun main() {
+    val koin = koinApplication {
+        modules(TestModule().module())
+    }.koin
+
+    koin.get<JsonLike>()
+}
+
+/* GENERATED_FIR_TAGS: classDeclaration, functionDeclaration, lambdaLiteral */


### PR DESCRIPTION
## Summary

Fixes issue #62 by reporting a compile-time error when a local top-level annotated provider function is not covered by any loaded `@ComponentScan` module and would be missing from the runtime Koin graph.

This also treats core `org.koin.dsl.koinApplication` as a Koin entrypoint for this diagnostic, matching the existing `startKoin` behavior and repo test usage.

## Verification

```bash
./test.sh
./test.sh --tests 'org.jetbrains.kotlin.compiler.plugin.template.runners.JvmErrorMessageTestGenerated'
./test.sh --tests 'org.jetbrains.kotlin.compiler.plugin.template.runners.JvmDiagnosticTestGenerated'
./test.sh --tests 'org.jetbrains.kotlin.compiler.plugin.template.runners.JvmBoxTestGenerated$Toplevel'
```
