### PR TITLE
Support definition annotations on objects via INSTANCE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ koin-compiler-plugin/
 
 ### Definition Annotations
 
-These annotations can be applied to **classes**, **functions inside @Module classes**, or **top-level functions**.
+These annotations can be applied to **classes**, **objects**, **functions inside @Module classes**, or **top-level functions**. An annotated `object` resolves to its singleton `INSTANCE` (no constructor call).
 
 | Annotation | Effect |
 |------------|--------|

--- a/docs/TRANSFORMATIONS.md
+++ b/docs/TRANSFORMATIONS.md
@@ -88,6 +88,20 @@ val MyModule.module: Module get() = module {
 }
 ```
 
+**On an `object`** the definition references the singleton `INSTANCE` instead of calling a
+constructor (an object has no public constructor). This applies to every definition
+annotation and to the `single<T>()` / `factory<T>()` DSL:
+
+```kotlin
+@Single
+object MyService
+```
+```kotlin
+buildSingle(MyService::class, null) { scope, params ->
+    MyService   // GET_OBJECT — the object's INSTANCE, not `MyService(...)`
+}
+```
+
 ### 2.2 @Factory
 
 **Input**:

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DefinitionCallBuilder.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DefinitionCallBuilder.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.util.isObject
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -581,7 +582,12 @@ class DefinitionCallBuilder(
     }
 
     /**
-     * Create a lambda expression for constructor: { Constructor(get(), get(), ...) }
+     * Create a lambda expression for the definition body.
+     * For a class: { Constructor(get(), get(), ...) }.
+     * For an `object`: { ObjectName } — references the singleton INSTANCE via irGetObject.
+     * An object has no public constructor, so emitting irCallConstructor would produce IR
+     * that fails lowering/validation (see issue #77). Mirrors the module-instance handling
+     * in ModuleFunctionResolver.buildModuleGetCall.
      */
     private fun createDefinitionLambda(
         constructor: IrConstructor,
@@ -590,13 +596,17 @@ class DefinitionCallBuilder(
         parentFunction: IrFunction
     ): IrExpression {
         return lambdaBuilder.create(returnTypeClass, builder, parentFunction) { irBuilder, scopeParam, paramsParam ->
-            irBuilder.irCallConstructor(constructor.symbol, emptyList()).apply {
-                constructor.regularParameters.forEachIndexed { index, param ->
-                    val scopeGet = irBuilder.irGet(scopeParam)
-                    val paramsGet = irBuilder.irGet(paramsParam)
-                    val argument = argumentGenerator.generateKoinArgumentForParameter(param, scopeGet, paramsGet, irBuilder)
-                    if (argument != null) {
-                        putRegularArgument(index, argument)
+            if (returnTypeClass.isObject) {
+                irBuilder.irGetObject(returnTypeClass.symbol)
+            } else {
+                irBuilder.irCallConstructor(constructor.symbol, emptyList()).apply {
+                    constructor.regularParameters.forEachIndexed { index, param ->
+                        val scopeGet = irBuilder.irGet(scopeParam)
+                        val paramsGet = irBuilder.irGet(paramsParam)
+                        val argument = argumentGenerator.generateKoinArgumentForParameter(param, scopeGet, paramsGet, irBuilder)
+                        if (argument != null) {
+                            putRegularArgument(index, argument)
+                        }
                     }
                 }
             }

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinDSLTransformer.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinDSLTransformer.kt
@@ -831,16 +831,22 @@ class KoinDSLTransformer(
             // Arg 1: Qualifier? (for workers, always use class name as qualifier)
             putRegularArgument(1, qualifierExtractor.createQualifierCall(effectiveQualifier, builder) ?: builder.irNull())
 
-            // Arg 2: Definition lambda { T(get(), get(), ...) }
+            // Arg 2: Definition lambda { T(get(), get(), ...) }, or { T } when T is an `object`.
+            // An object has no public constructor, so referencing its INSTANCE via irGetObject
+            // is required — emitting irCallConstructor produces IR that fails lowering (issue #77).
             val parentFunc = currentFunction ?: return call
             putRegularArgument(2, lambdaBuilder.create(targetClass, builder, parentFunc) { lb, scopeParam, paramsParam ->
-                lb.irCallConstructor(constructor.symbol, emptyList()).apply {
-                    constructor.regularParameters.forEachIndexed { index, param ->
-                        val scopeGet = lb.irGet(scopeParam)
-                        val paramsGet = lb.irGet(paramsParam)
-                        val argument = argumentGenerator.generateKoinArgumentForParameter(param, scopeGet, paramsGet, lb)
-                        if (argument != null) {
-                            putRegularArgument(index, argument)
+                if (targetClass.isObject) {
+                    lb.irGetObject(targetClass.symbol)
+                } else {
+                    lb.irCallConstructor(constructor.symbol, emptyList()).apply {
+                        constructor.regularParameters.forEachIndexed { index, param ->
+                            val scopeGet = lb.irGet(scopeParam)
+                            val paramsGet = lb.irGet(paramsParam)
+                            val argument = argumentGenerator.generateKoinArgumentForParameter(param, scopeGet, paramsGet, lb)
+                            if (argument != null) {
+                                putRegularArgument(index, argument)
+                            }
                         }
                     }
                 }

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -43,6 +43,18 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     }
 
     @Test
+    @TestMetadata("object_binding.kt")
+    public void testObject_binding() {
+      runTest("koin-compiler-plugin/testData/box/annotations/object_binding.kt");
+    }
+
+    @Test
+    @TestMetadata("object_singleton.kt")
+    public void testObject_singleton() {
+      runTest("koin-compiler-plugin/testData/box/annotations/object_singleton.kt");
+    }
+
+    @Test
     @TestMetadata("single_fun_created_at_start.kt")
     public void testSingle_fun_created_at_start() {
       runTest("koin-compiler-plugin/testData/box/annotations/single_fun_created_at_start.kt");
@@ -132,6 +144,12 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @TestMetadata("single_basic.kt")
     public void testSingle_basic() {
       runTest("koin-compiler-plugin/testData/box/dsl/single_basic.kt");
+    }
+
+    @Test
+    @TestMetadata("single_object.kt")
+    public void testSingle_object() {
+      runTest("koin-compiler-plugin/testData/box/dsl/single_object.kt");
     }
 
     @Test

--- a/koin-compiler-plugin/testData/box/annotations/object_binding.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/object_binding.fir.ir.txt
@@ -1,0 +1,247 @@
+FILE fqName:<root> fileName:/appModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.AppModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: <root>.AppModule): org.koin.core.module.Module declared in <root>'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                CALL 'public final fun bind <S> (<this>: org.koin.core.definition.KoinDefinition<*>, clazz: kotlin.reflect.KClass<S of org.koin.plugin.module.dsl.bind>): org.koin.core.definition.KoinDefinition<*> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<*> origin=null
+                  TYPE_ARG S: <root>.Loader<K of <root>.Loader, V of <root>.Loader>
+                  ARG <this>: CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                    TYPE_ARG T: <root>.LengthLoader
+                    ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                    ARG kclass: CLASS_REFERENCE 'CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]' type=kotlin.reflect.KClass<<root>.LengthLoader>
+                    ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                    ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.LengthLoader> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.LengthLoader
+                        VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                        VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                        BLOCK_BODY
+                          RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.LengthLoader declared in <root>.module.<anonymous>'
+                            GET_OBJECT 'CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]' type=<root>.LengthLoader
+                  ARG clazz: CLASS_REFERENCE 'CLASS INTERFACE name:Loader modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Loader<K of <root>.Loader, V of <root>.Loader>>
+FILE fqName:org.koin.plugin.hints fileName:/koin_hints_AppModule_9b690110ed8c2a44.kt
+  FUN name:componentscan_appModule_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.LengthLoader
+    VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.Loader<kotlin.Any?, kotlin.Any?>
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:<root> fileName:/test.kt
+  CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AppModule
+    CONSTRUCTOR visibility:public returnType:<root>.AppModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:BaseLoader modality:ABSTRACT visibility:public superTypes:[<root>.Loader<K of <root>.BaseLoader, V of <root>.BaseLoader>]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader>
+    TYPE_PARAMETER name:K index:0 variance: superTypes:[kotlin.Any] reified:false
+    TYPE_PARAMETER name:V index:1 variance: superTypes:[kotlin.Any] reified:false
+    PROPERTY name:loaderName visibility:public modality:OPEN [val]
+      overridden:
+        public abstract loaderName: kotlin.String declared in <root>.Loader
+      FIELD PROPERTY_BACKING_FIELD name:loaderName type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun CHECK_NOT_NULL <T0> (arg0: T0 of kotlin.internal.ir.CHECK_NOT_NULL?): {T0 of kotlin.internal.ir.CHECK_NOT_NULL & Any} declared in kotlin.internal.ir' type=kotlin.String origin=EXCLEXCL
+            TYPE_ARG T0: kotlin.String
+            ARG arg0: CALL 'public abstract fun <get-qualifiedName> (): kotlin.String? declared in kotlin.reflect.KClass' type=kotlin.String? origin=GET_PROPERTY
+              ARG <this>: GET_CLASS type=kotlin.reflect.KClass<out <root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader>>
+                GET_VAR '<this>: <root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader> declared in <root>.BaseLoader' type=<root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader> origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-loaderName> visibility:public modality:OPEN returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader>
+        correspondingProperty: PROPERTY name:loaderName visibility:public modality:OPEN [val]
+        overridden:
+          public abstract fun <get-loaderName> (): kotlin.String declared in <root>.Loader
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun <get-loaderName> (): kotlin.String declared in <root>.BaseLoader'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:loaderName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader> declared in <root>.BaseLoader.<get-loaderName>' type=<root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader> origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader> [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:BaseLoader modality:ABSTRACT visibility:public superTypes:[<root>.Loader<K of <root>.BaseLoader, V of <root>.BaseLoader>]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Loader
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.Loader
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.Loader
+    FUN name:batchLoad visibility:public modality:ABSTRACT returnType:kotlin.collections.Map<K of <root>.BaseLoader, V of <root>.BaseLoader> [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BaseLoader<K of <root>.BaseLoader, V of <root>.BaseLoader>
+      VALUE_PARAMETER kind:Regular name:keys index:1 type:kotlin.collections.Set<K of <root>.BaseLoader>
+  CLASS INTERFACE name:Loader modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Loader<K of <root>.Loader, V of <root>.Loader>
+    TYPE_PARAMETER name:K index:0 variance: superTypes:[kotlin.Any] reified:false
+    TYPE_PARAMETER name:V index:1 variance: superTypes:[kotlin.Any] reified:false
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    PROPERTY name:loaderName visibility:public modality:ABSTRACT [val]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-loaderName> visibility:public modality:ABSTRACT returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Loader<K of <root>.Loader, V of <root>.Loader>
+        correspondingProperty: PROPERTY name:loaderName visibility:public modality:ABSTRACT [val]
+  CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]
+    annotations:
+      Single(binds = [CLASS_REFERENCE 'CLASS INTERFACE name:Loader modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Loader<*, *>>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.LengthLoader
+    CONSTRUCTOR visibility:private returnType:<root>.LengthLoader [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.BaseLoader'
+          TYPE_ARG K: kotlin.String
+          TYPE_ARG V: kotlin.Int
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BaseLoader
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.BaseLoader
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.BaseLoader
+    FUN name:batchLoad visibility:public modality:OPEN returnType:kotlin.collections.Map<kotlin.String, kotlin.Int> [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.LengthLoader
+      VALUE_PARAMETER kind:Regular name:keys index:1 type:kotlin.collections.Set<kotlin.String>
+      overridden:
+        public abstract fun batchLoad (keys: kotlin.collections.Set<K of <root>.BaseLoader>): kotlin.collections.Map<K of <root>.BaseLoader, V of <root>.BaseLoader> declared in <root>.BaseLoader
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun batchLoad (keys: kotlin.collections.Set<kotlin.String>): kotlin.collections.Map<kotlin.String, kotlin.Int> declared in <root>.LengthLoader'
+          CALL 'public final fun associateWith <K, V> (<this>: kotlin.collections.Iterable<K of kotlin.collections.associateWith>, valueSelector: kotlin.Function1<K of kotlin.collections.associateWith, V of kotlin.collections.associateWith>): kotlin.collections.Map<K of kotlin.collections.associateWith, V of kotlin.collections.associateWith> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, kotlin.Int> origin=null
+            TYPE_ARG K: kotlin.String
+            TYPE_ARG V: kotlin.Int
+            ARG <this>: GET_VAR 'keys: kotlin.collections.Set<kotlin.String> declared in <root>.LengthLoader.batchLoad' type=kotlin.collections.Set<kotlin.String> origin=null
+            ARG valueSelector: FUN_EXPR type=kotlin.Function1<kotlin.String, kotlin.Int> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Int
+                VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.String
+                BLOCK_BODY
+                  RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: kotlin.String): kotlin.Int declared in <root>.LengthLoader.batchLoad'
+                    CALL 'public open fun <get-length> (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=GET_PROPERTY
+                      ARG <this>: GET_VAR 'it: kotlin.String declared in <root>.LengthLoader.batchLoad.<anonymous>' type=kotlin.String origin=null
+    FUN name:invoke visibility:public modality:FINAL returnType:<root>.LengthLoader [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.LengthLoader
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun invoke (): <root>.LengthLoader declared in <root>.LengthLoader'
+          GET_VAR '<this>: <root>.LengthLoader declared in <root>.LengthLoader.invoke' type=<root>.LengthLoader origin=null
+    PROPERTY FAKE_OVERRIDE name:loaderName visibility:public modality:OPEN [fake_override,val]
+      overridden:
+        public open loaderName: kotlin.String declared in <root>.BaseLoader
+      FUN FAKE_OVERRIDE name:<get-loaderName> visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BaseLoader<kotlin.String, kotlin.Int>
+        correspondingProperty: PROPERTY FAKE_OVERRIDE name:loaderName visibility:public modality:OPEN [fake_override,val]
+        overridden:
+          public open fun <get-loaderName> (): kotlin.String declared in <root>.BaseLoader
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: CALL 'public final fun module (<this>: <root>.AppModule): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=null
+                        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.AppModule' type=<root>.AppModule origin=null
+      VAR name:loaders type:kotlin.collections.List<<root>.Loader<*, *>> [val]
+        CALL 'public final fun getAll <T> (): kotlin.collections.List<T of org.koin.core.Koin.getAll> declared in org.koin.core.Koin' type=kotlin.collections.List<<root>.Loader<*, *>> origin=null
+          TYPE_ARG T: <root>.Loader<*, *>
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public abstract fun <get-size> (): kotlin.Int declared in kotlin.collections.List' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val loaders: kotlin.collections.List<<root>.Loader<*, *>> declared in <root>.box' type=kotlin.collections.List<<root>.Loader<*, *>> origin=null
+              ARG arg1: CONST Int type=kotlin.Int value=1
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: expected 1 loader, got "
+              CALL 'public abstract fun <get-size> (): kotlin.Int declared in kotlin.collections.List' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_VAR 'val loaders: kotlin.collections.List<<root>.Loader<*, *>> declared in <root>.box' type=kotlin.collections.List<<root>.Loader<*, *>> origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQEQ
+            ARG <this>: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQEQ
+              ARG arg0: CALL 'public final fun first <T> (<this>: kotlin.collections.List<T of kotlin.collections.first>): T of kotlin.collections.first declared in kotlin.collections' type=<root>.Loader<*, *> origin=null
+                TYPE_ARG T: <root>.Loader<*, *>
+                ARG <this>: GET_VAR 'val loaders: kotlin.collections.List<<root>.Loader<*, *>> declared in <root>.box' type=kotlin.collections.List<<root>.Loader<*, *>> origin=null
+              ARG arg1: GET_OBJECT 'CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]' type=<root>.LengthLoader
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: bound loader is not the object INSTANCE"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQEQ
+            ARG <this>: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQEQ
+              ARG arg0: CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.Loader<kotlin.String, kotlin.Int> origin=null
+                TYPE_ARG T: <root>.Loader<kotlin.String, kotlin.Int>
+                ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+              ARG arg1: GET_OBJECT 'CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]' type=<root>.LengthLoader
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: get<Loader>() is not the INSTANCE"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQEQ
+            ARG <this>: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQEQ
+              ARG arg0: CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.LengthLoader origin=null
+                TYPE_ARG T: <root>.LengthLoader
+                ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+              ARG arg1: GET_OBJECT 'CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]' type=<root>.LengthLoader
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: get<LengthLoader>() is not the INSTANCE"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public open fun <get-loaderName> (): kotlin.String declared in <root>.LengthLoader' type=kotlin.String origin=GET_PROPERTY
+                ARG <this>: GET_OBJECT 'CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]' type=<root>.LengthLoader
+              ARG arg1: CONST String type=kotlin.String value="LengthLoader"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: wrong loaderName "
+              CALL 'public open fun <get-loaderName> (): kotlin.String declared in <root>.LengthLoader' type=kotlin.String origin=GET_PROPERTY
+                ARG <this>: GET_OBJECT 'CLASS OBJECT name:LengthLoader modality:FINAL visibility:public superTypes:[<root>.BaseLoader<kotlin.String, kotlin.Int>]' type=<root>.LengthLoader
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/koin-compiler-plugin/testData/box/annotations/object_binding.fir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/object_binding.fir.txt
@@ -1,0 +1,80 @@
+FILE: test.kt
+    public abstract interface Loader<K : R|kotlin/Any|, V : R|kotlin/Any|> : R|kotlin/Any| {
+        public abstract val loaderName: R|kotlin/String|
+            public get(): R|kotlin/String|
+
+    }
+    public abstract class BaseLoader<K : R|kotlin/Any|, V : R|kotlin/Any|> : R|Loader<K, V>| {
+        public constructor<K : R|kotlin/Any|, V : R|kotlin/Any|>(): R|BaseLoader<K, V>| {
+            super<R|kotlin/Any|>()
+        }
+
+        public open override val loaderName: R|kotlin/String| = <getClass>(this@R|/BaseLoader|).R|SubstitutionOverride<kotlin/reflect/KClass.qualifiedName: R|kotlin/String?|>|!!
+            public get(): R|kotlin/String|
+
+        public abstract suspend fun batchLoad(keys: R|kotlin/collections/Set<K>|): R|kotlin/collections/Map<K, V>|
+
+    }
+    @R|org/koin/core/annotation/Single|(binds = <collectionLiteralCall>(<getClass>(Q|Loader|))) public final object LengthLoader : R|BaseLoader<kotlin/String, kotlin/Int>| {
+        private constructor(): R|LengthLoader| {
+            super<R|BaseLoader<kotlin/String, kotlin/Int>|>()
+        }
+
+        public final operator fun invoke(): R|LengthLoader| {
+            ^invoke this@R|/LengthLoader|
+        }
+
+        public open override suspend fun batchLoad(keys: R|kotlin/collections/Set<kotlin/String>|): R|kotlin/collections/Map<kotlin/String, kotlin/Int>| {
+            ^batchLoad R|<local>/keys|.R|kotlin/collections/associateWith|<R|kotlin/String|, R|kotlin/Int|>(<L> = associateWith@fun <anonymous>(it: R|kotlin/String|): R|kotlin/Int| <inline=Inline, kind=UNKNOWN>  {
+                ^ R|<local>/it|.R|kotlin/String.length|
+            }
+            )
+        }
+
+    }
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|() public final class AppModule : R|kotlin/Any| {
+        public constructor(): R|AppModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/AppModule.AppModule|().R|/module|())
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval loaders: R|kotlin/collections/List<Loader<*, *>>| = R|<local>/koin|.R|org/koin/core/Koin.getAll|<R|Loader<*, *>|>()
+        when () {
+            !=(R|<local>/loaders|.R|SubstitutionOverride<kotlin/collections/List.size: R|kotlin/Int|>|, Int(1)) ->  {
+                ^box <strcat>(String(FAIL: expected 1 loader, got ), R|<local>/loaders|.R|SubstitutionOverride<kotlin/collections/List.size: R|kotlin/Int|>|)
+            }
+        }
+
+        when () {
+            !==(R|<local>/loaders|.R|kotlin/collections/first|<R|Loader<*, *>|>(), Q|LengthLoader|) ->  {
+                ^box String(FAIL: bound loader is not the object INSTANCE)
+            }
+        }
+
+        when () {
+            !==(R|<local>/koin|.R|org/koin/core/Koin.get|<R|Loader<kotlin/String, kotlin/Int>|>(), Q|LengthLoader|) ->  {
+                ^box String(FAIL: get<Loader>() is not the INSTANCE)
+            }
+        }
+
+        when () {
+            !==(R|<local>/koin|.R|org/koin/core/Koin.get|<R|LengthLoader|>(), Q|LengthLoader|) ->  {
+                ^box String(FAIL: get<LengthLoader>() is not the INSTANCE)
+            }
+        }
+
+        when () {
+            !=(Q|LengthLoader|.R|SubstitutionOverride</LengthLoader.loaderName: R|kotlin/String|>|, String(LengthLoader)) ->  {
+                ^box <strcat>(String(FAIL: wrong loaderName ), Q|LengthLoader|.R|SubstitutionOverride</LengthLoader.loaderName: R|kotlin/String|>|)
+            }
+        }
+
+        ^box String(OK)
+    }
+FILE: /appModuleModule.kt
+    public final fun R|AppModule|.module(): R|org/koin/core/module/Module|

--- a/koin-compiler-plugin/testData/box/annotations/object_binding.kt
+++ b/koin-compiler-plugin/testData/box/annotations/object_binding.kt
@@ -1,0 +1,46 @@
+// FILE: test.kt
+import org.koin.dsl.koinApplication
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+
+// Real-world shape from issue #77: a stateless `object` bound to a framework interface
+// and collected through it, on top of a shared abstract base.
+
+interface Loader<K : Any, V : Any> {
+    val loaderName: String
+}
+
+abstract class BaseLoader<K : Any, V : Any> : Loader<K, V> {
+    override val loaderName: String = this::class.qualifiedName!!
+    abstract suspend fun batchLoad(keys: Set<K>): Map<K, V>
+}
+
+@Single([Loader::class])
+object LengthLoader : BaseLoader<String, Int>() {
+    operator fun invoke() = this // KSP workaround, ignored by the compiler plugin
+
+    override suspend fun batchLoad(keys: Set<String>): Map<String, Int> = keys.associateWith { it.length }
+}
+
+@Module
+@ComponentScan
+class AppModule
+
+fun box(): String {
+    val koin = koinApplication {
+        modules(AppModule().module())
+    }.koin
+
+    // The @Single object is bound to the Loader interface and collected via getAll.
+    val loaders = koin.getAll<Loader<*, *>>()
+    if (loaders.size != 1) return "FAIL: expected 1 loader, got ${loaders.size}"
+    if (loaders.first() !== LengthLoader) return "FAIL: bound loader is not the object INSTANCE"
+
+    // Resolvable by the interface and by the concrete object type, both the INSTANCE.
+    if (koin.get<Loader<String, Int>>() !== LengthLoader) return "FAIL: get<Loader>() is not the INSTANCE"
+    if (koin.get<LengthLoader>() !== LengthLoader) return "FAIL: get<LengthLoader>() is not the INSTANCE"
+    if (LengthLoader.loaderName != "LengthLoader") return "FAIL: wrong loaderName ${LengthLoader.loaderName}"
+
+    return "OK"
+}

--- a/koin-compiler-plugin/testData/box/annotations/object_singleton.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/object_singleton.fir.ir.txt
@@ -1,0 +1,114 @@
+FILE fqName:org.koin.plugin.hints fileName:/koin_hints_TestModule_8cd674464db476dd.kt
+  FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyService
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:<root> fileName:/test.kt
+  CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestModule
+    CONSTRUCTOR visibility:public returnType:<root>.TestModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Single(binds = <null>, createdAtStart = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MyService
+    CONSTRUCTOR visibility:private returnType:<root>.MyService [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:hello visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.MyService
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun hello (): kotlin.String declared in <root>.MyService'
+          CONST String type=kotlin.String value="hello"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: CALL 'public final fun module (<this>: <root>.TestModule): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=null
+                        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TestModule' type=<root>.TestModule origin=null
+      VAR name:resolved type:<root>.MyService [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.MyService origin=null
+          TYPE_ARG T: <root>.MyService
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQEQ
+            ARG <this>: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQEQ
+              ARG arg0: GET_VAR 'val resolved: <root>.MyService declared in <root>.box' type=<root>.MyService origin=null
+              ARG arg1: GET_OBJECT 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.MyService
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: @Single object did not resolve to INSTANCE"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun hello (): kotlin.String declared in <root>.MyService' type=kotlin.String origin=null
+                ARG <this>: GET_VAR 'val resolved: <root>.MyService declared in <root>.box' type=<root>.MyService origin=null
+              ARG arg1: CONST String type=kotlin.String value="hello"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: wrong instance behavior"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"
+FILE fqName:<root> fileName:/testModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.TestModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: <root>.TestModule): org.koin.core.module.Module declared in <root>'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                  TYPE_ARG T: <root>.MyService
+                  ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                  ARG kclass: CLASS_REFERENCE 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.MyService>
+                  ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.MyService> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.MyService
+                      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                      VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.MyService declared in <root>.module.<anonymous>'
+                          GET_OBJECT 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.MyService

--- a/koin-compiler-plugin/testData/box/annotations/object_singleton.fir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/object_singleton.fir.txt
@@ -1,0 +1,39 @@
+FILE: test.kt
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|() public final class TestModule : R|kotlin/Any| {
+        public constructor(): R|TestModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|org/koin/core/annotation/Single|() public final object MyService : R|kotlin/Any| {
+        private constructor(): R|MyService| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final fun hello(): R|kotlin/String| {
+            ^hello String(hello)
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/TestModule.TestModule|().R|/module|())
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval resolved: R|MyService| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|MyService|>()
+        when () {
+            !==(R|<local>/resolved|, Q|MyService|) ->  {
+                ^box String(FAIL: @Single object did not resolve to INSTANCE)
+            }
+        }
+
+        when () {
+            !=(R|<local>/resolved|.R|/MyService.hello|(), String(hello)) ->  {
+                ^box String(FAIL: wrong instance behavior)
+            }
+        }
+
+        ^box String(OK)
+    }
+FILE: /testModuleModule.kt
+    public final fun R|TestModule|.module(): R|org/koin/core/module/Module|

--- a/koin-compiler-plugin/testData/box/annotations/object_singleton.kt
+++ b/koin-compiler-plugin/testData/box/annotations/object_singleton.kt
@@ -1,0 +1,26 @@
+// FILE: test.kt
+import org.koin.dsl.koinApplication
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Single
+
+@Module
+@ComponentScan
+class TestModule
+
+@Single
+object MyService {
+    fun hello() = "hello"
+}
+
+fun box(): String {
+    val koin = koinApplication {
+        modules(TestModule().module())
+    }.koin
+
+    // @Single on an `object` resolves to its INSTANCE, not a fresh construction.
+    val resolved = koin.get<MyService>()
+    if (resolved !== MyService) return "FAIL: @Single object did not resolve to INSTANCE"
+    if (resolved.hello() != "hello") return "FAIL: wrong instance behavior"
+    return "OK"
+}

--- a/koin-compiler-plugin/testData/box/dsl/single_object.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_object.fir.ir.txt
@@ -1,0 +1,86 @@
+FILE fqName:org.koin.plugin.hints fileName:/koin_dsl_hints_main__test_kt_06549e611b62f6c5.kt
+  FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyService
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:<root> fileName:/test.kt
+  CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MyService
+    CONSTRUCTOR visibility:private returnType:<root>.MyService [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:hello visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.MyService
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun hello (): kotlin.String declared in <root>.MyService'
+          CONST String type=kotlin.String value="hello"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:m type:org.koin.core.module.Module [val]
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:$this$module index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                  CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                    TYPE_ARG T: <root>.MyService
+                    ARG <this>: GET_VAR '$this$module: org.koin.core.module.Module declared in <root>.box.<anonymous>' type=org.koin.core.module.Module origin=IMPLICIT_ARGUMENT
+                    ARG kclass: CLASS_REFERENCE 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.MyService>
+                    ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                    ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.MyService> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.MyService
+                        VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                        VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                        BLOCK_BODY
+                          RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.MyService declared in <root>.box.<anonymous>'
+                            GET_OBJECT 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.MyService
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: GET_VAR 'val m: org.koin.core.module.Module declared in <root>.box' type=org.koin.core.module.Module origin=null
+      VAR name:resolved type:<root>.MyService [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.MyService origin=null
+          TYPE_ARG T: <root>.MyService
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQEQ
+            ARG <this>: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQEQ
+              ARG arg0: GET_VAR 'val resolved: <root>.MyService declared in <root>.box' type=<root>.MyService origin=null
+              ARG arg1: GET_OBJECT 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.MyService
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: single<object>() did not resolve to INSTANCE"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public final fun hello (): kotlin.String declared in <root>.MyService' type=kotlin.String origin=null
+                ARG <this>: GET_VAR 'val resolved: <root>.MyService declared in <root>.box' type=<root>.MyService origin=null
+              ARG arg1: CONST String type=kotlin.String value="hello"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: wrong instance behavior"
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/koin-compiler-plugin/testData/box/dsl/single_object.fir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/single_object.fir.txt
@@ -1,0 +1,35 @@
+FILE: test.kt
+    public final object MyService : R|kotlin/Any| {
+        private constructor(): R|MyService| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final fun hello(): R|kotlin/String| {
+            ^hello String(hello)
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval m: R|org/koin/core/module/Module| = R|org/koin/dsl/module|(<L> = module@fun R|org/koin/core/module/Module|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/plugin/module/dsl/single|<R|MyService|>()
+        }
+        )
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|<local>/m|)
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval resolved: R|MyService| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|MyService|>()
+        when () {
+            !==(R|<local>/resolved|, Q|MyService|) ->  {
+                ^box String(FAIL: single<object>() did not resolve to INSTANCE)
+            }
+        }
+
+        when () {
+            !=(R|<local>/resolved|.R|/MyService.hello|(), String(hello)) ->  {
+                ^box String(FAIL: wrong instance behavior)
+            }
+        }
+
+        ^box String(OK)
+    }

--- a/koin-compiler-plugin/testData/box/dsl/single_object.kt
+++ b/koin-compiler-plugin/testData/box/dsl/single_object.kt
@@ -1,0 +1,21 @@
+// FILE: test.kt
+import org.koin.dsl.module
+import org.koin.dsl.koinApplication
+import org.koin.plugin.module.dsl.single
+
+object MyService {
+    fun hello() = "hello"
+}
+
+fun box(): String {
+    val m = module {
+        single<MyService>()
+    }
+    val koin = koinApplication { modules(m) }.koin
+
+    // single<T>() on an `object` resolves to its INSTANCE, not a fresh construction.
+    val resolved = koin.get<MyService>()
+    if (resolved !== MyService) return "FAIL: single<object>() did not resolve to INSTANCE"
+    if (resolved.hello() != "hello") return "FAIL: wrong instance behavior"
+    return "OK"
+}

--- a/playground-apps/app-kmp-klib/src/commonMain/kotlin/playground/App.kt
+++ b/playground-apps/app-kmp-klib/src/commonMain/kotlin/playground/App.kt
@@ -54,6 +54,17 @@ fun authApiClient(dep: AuthDep): ApiClient = ApiClient("auth")
 @Named("plain")
 fun plainApiClient(dep: PlainDep): ApiClient = ApiClient("plain")
 
+// @Single on an `object` bound to an interface (compiler#77). Must reference the
+// singleton INSTANCE and still emit the .bind() chain.
+interface Settings {
+    val label: String
+}
+
+@Single([Settings::class])
+object SettingsHolder : Settings {
+    override val label: String = "settings"
+}
+
 class EagerService
 
 @Module


### PR DESCRIPTION
Closes #77

A definition annotation (e.g. `@Single`) on a Kotlin object made the plugin emit a constructor call for the object. An object has no public constructor, so this produced invalid IR. With compiler assertions on, it failed lowering with an AssertionError. With assertions off, it compiled and then crashed at runtime with NoSuchMethodError, while Gradle still reported BUILD SUCCESSFUL.

The definition body now references the singleton INSTANCE with irGetObject when the target is an object. This mirrors the existing object handling in `ModuleFunctionResolver.buildModuleGetCall`. Both the annotation path (DefinitionCallBuilder.createDefinitionLambda, used by the root and scoped builders) and the DSL path (KoinDSLTransformer.handleTypeParameterCall for single<T>() and friends) are covered. Interface binding on an object still emits the .bind() chain around the INSTANCE reference.

Tests
- box/annotations/object_binding.kt mirrors the real use case from the issue. An object is bound to a framework interface with `@Single([Loader::class])`, extends a shared abstract base, and is collected through the interface with getAll. It fails on the unfixed plugin with an IR validation error and passes after the fix.
- box/annotations/object_singleton.kt is the minimal `@Single` object case.
- box/dsl/single_object.kt covers the same case for single<T>().
- playground-apps/app-kmp-klib adds an interface-bound `@Single` object so the change is compiled on the KLIB targets iosArm64 and wasmJs.

Docs updated to note that objects are supported and resolve to INSTANCE.