### PR TITLE
JSR330 Compatibility toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,7 @@ koinCompiler {
     strictSafetyForceOff = true // Escape hatch: confirms a detected entry point is a misfire, actually disables strictSafety (default: false)
     logSeverity = "warning"           // Severity of informational output (default: "warning"; set "info" under allWarningsAsErrors)
     versionCheckSeverity = "warning"  // Severity of the Kotlin-version-compatibility warning (default: "warning"; independent of logSeverity)
+    jsr330 = true              // Process jakarta.inject.*/javax.inject.* (JSR-330) annotations (default: true)
 }
 ```
 
@@ -296,6 +297,14 @@ single<Service>()
 ```
 
 Set `skipDefaultValues = false` to always inject all parameters from the DI container, ignoring Kotlin default values.
+
+### JSR-330 Support
+
+`jsr330` (default: `true`) controls whether `jakarta.inject.*` / `javax.inject.*` annotations
+(`@Singleton`, `@Inject`, `@Named`, `@Qualifier`) are recognized alongside Koin's own annotations.
+Set `jsr330 = false` to disable this entirely — only `org.koin.core.annotation.*` annotations are
+then processed, and JSR-330-only annotated classes are silently skipped (not registered under any
+type), matching a definition-annotation-less class today.
 
 ## Compatibility — verified range + version gate
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ koinCompiler {
     debugLogs = true          // Log internal processing (verbose)
     unsafeDslChecks = true    // Validates create() is the only instruction in lambda (default: true)
     skipDefaultValues = true  // Skip injection for parameters with default values (default: true)
+    jsr330 = true             // Process jakarta.inject.*/javax.inject.* annotations (default: true)
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,14 @@ build-config = "5.6.5"
 bcv = "0.16.3"
 junit = "4.13.2"
 nmcp = "1.0.1"
+jakarta-inject = "2.0.1"
 
 [libraries]
 junit = { module = "junit:junit", version.ref = "junit" }
 koin-annotations = { module = "io.insert-koin:koin-annotations-jvm", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core-jvm", version.ref = "koin" }
 kotzilla-core = { module = "io.kotzilla:kotzilla-core-jvm", version.ref = "kotzilla-sdk" }
+jakarta-inject = { module = "jakarta.inject:jakarta.inject-api", version.ref = "jakarta-inject" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/koin-compiler-gradle-plugin/src/org/koin/compiler/plugin/KoinGradleExtension.kt
+++ b/koin-compiler-gradle-plugin/src/org/koin/compiler/plugin/KoinGradleExtension.kt
@@ -128,4 +128,11 @@ open class KoinGradleExtension(objectFactory: ObjectFactory) {
      * blocking an `allWarningsAsErrors` build and you've already assessed the compatibility risk.
      */
     val versionCheckSeverity: Property<String> = objectFactory.property(String::class.java).convention("warning")
+
+    /**
+     * Enable processing of `jakarta.inject.*` / `javax.inject.*` (JSR-330) annotations (default: true).
+     * Set to false to skip JSR-330 annotation processing entirely — only Koin's own annotations
+     * (`@Single`, `@Factory`, etc.) are then recognized.
+     */
+    val jsr330: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(true)
 }

--- a/koin-compiler-gradle-plugin/src/org/koin/compiler/plugin/KoinGradlePlugin.kt
+++ b/koin-compiler-gradle-plugin/src/org/koin/compiler/plugin/KoinGradlePlugin.kt
@@ -23,6 +23,7 @@ class KoinGradlePlugin : KotlinCompilerPluginSupportPlugin {
         const val OPTION_MODULE_ID = "moduleId"
         const val OPTION_LOG_SEVERITY = "logSeverity"
         const val OPTION_VERSION_CHECK_SEVERITY = "versionCheckSeverity"
+        const val OPTION_JSR330 = "jsr330"
     }
 
     private fun configureStrictSafety(
@@ -174,7 +175,8 @@ class KoinGradlePlugin : KotlinCompilerPluginSupportPlugin {
                 SubpluginOption(OPTION_AI_ASSIST, extension.aiAssist.get().toString()),
                 SubpluginOption(OPTION_MODULE_ID, moduleId),
                 SubpluginOption(OPTION_LOG_SEVERITY, extension.logSeverity.get()),
-                SubpluginOption(OPTION_VERSION_CHECK_SEVERITY, extension.versionCheckSeverity.get())
+                SubpluginOption(OPTION_VERSION_CHECK_SEVERITY, extension.versionCheckSeverity.get()),
+                SubpluginOption(OPTION_JSR330, extension.jsr330.get().toString())
             )
         }
     }

--- a/koin-compiler-plugin/build.gradle.kts
+++ b/koin-compiler-plugin/build.gradle.kts
@@ -57,6 +57,9 @@ dependencies {
     // Kotzilla SDK for @Monitor annotation testing
     annotationsRuntimeClasspath(libs.kotzilla.core)
 
+    // jakarta.inject.* (JSR-330) for jsr330 option box tests
+    annotationsRuntimeClasspath(libs.jakarta.inject)
+
     // Dependencies required to run the internal test framework.
     testRuntimeOnly(libs.junit)
     testRuntimeOnly(kotlin("reflect"))

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinAnnotationFqNames.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinAnnotationFqNames.kt
@@ -152,6 +152,29 @@ object KoinAnnotationFqNames {
     /** javax.inject.Qualifier - JSR-330 qualifier meta-annotation (legacy). */
     val JAVAX_QUALIFIER = FqName("javax.inject.Qualifier")
 
+    /**
+     * FqNames recognized as a string-qualifier annotation (`@Named("x")`): Koin's own [NAMED],
+     * plus [JAKARTA_NAMED]/[JAVAX_NAMED] when [jsr330Enabled]. Single source of truth for the
+     * three call sites that used to re-derive this same jsr330-gated OR chain independently
+     * (FIR's `extractQualifierNameFromAnnotations`, IR's `QualifierExtractor.extractFromDeclaration`
+     * and `extractFromParameter`).
+     */
+    fun namedAnnotationFqNames(jsr330Enabled: Boolean): Set<FqName> =
+        if (jsr330Enabled) setOf(NAMED, JAKARTA_NAMED, JAVAX_NAMED) else setOf(NAMED)
+
+    /**
+     * FqNames that mark an annotation class as a qualifier meta-annotation, i.e. `@Named`
+     * itself counts (a custom annotation meta-annotated with plain `@Named` is a valid custom
+     * qualifier — see `QualifierAndJsr330Test.kt`'s `@Named annotation class InMemory`).
+     * Includes [JAKARTA_QUALIFIER]/[JAVAX_QUALIFIER] when [jsr330Enabled].
+     *
+     * Only used by [org.koin.compiler.plugin.ir.QualifierExtractor.isQualifierMetaAnnotation] —
+     * the FIR cross-module `qualifierAnnotationPredicate` matches a narrower, pre-existing set
+     * (no [NAMED]) and is intentionally left alone here to avoid a silent behavior change.
+     */
+    fun qualifierMetaAnnotationFqNames(jsr330Enabled: Boolean): Set<FqName> =
+        if (jsr330Enabled) setOf(QUALIFIER, NAMED, JAKARTA_QUALIFIER, JAVAX_QUALIFIER) else setOf(QUALIFIER, NAMED)
+
     // ================================================================================
     // Koin Core Classes
     // ================================================================================

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinCommandLineProcessor.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinCommandLineProcessor.kt
@@ -20,6 +20,7 @@ object KoinConfigurationKeys {
     val MODULE_ID: CompilerConfigurationKey<String> = CompilerConfigurationKey.create("koin.moduleId")
     val LOG_SEVERITY: CompilerConfigurationKey<String> = CompilerConfigurationKey.create("koin.logSeverity")
     val VERSION_CHECK_SEVERITY: CompilerConfigurationKey<String> = CompilerConfigurationKey.create("koin.versionCheckSeverity")
+    val JSR330: CompilerConfigurationKey<Boolean> = CompilerConfigurationKey.create("koin.jsr330")
 }
 
 @Suppress("unused") // Used via reflection.
@@ -35,6 +36,7 @@ class KoinCommandLineProcessor : CommandLineProcessor {
         const val OPTION_MODULE_ID = KoinPluginConstants.OPTION_MODULE_ID
         const val OPTION_LOG_SEVERITY = KoinPluginConstants.OPTION_LOG_SEVERITY
         const val OPTION_VERSION_CHECK_SEVERITY = KoinPluginConstants.OPTION_VERSION_CHECK_SEVERITY
+        const val OPTION_JSR330 = KoinPluginConstants.OPTION_JSR330
     }
 
     override val pluginId: String = BuildConfig.KOTLIN_PLUGIN_ID
@@ -93,6 +95,12 @@ class KoinCommandLineProcessor : CommandLineProcessor {
             valueDescription = "<warning|info>",
             description = "Severity of the Kotlin-version-compatibility warning, independent of logSeverity. 'info' is safe under allWarningsAsErrors.",
             required = false
+        ),
+        CliOption(
+            optionName = OPTION_JSR330,
+            valueDescription = "<true|false>",
+            description = "Enable processing of jakarta.inject.* / javax.inject.* (JSR-330) annotations",
+            required = false
         )
     )
 
@@ -107,6 +115,7 @@ class KoinCommandLineProcessor : CommandLineProcessor {
             OPTION_MODULE_ID -> configuration.put(KoinConfigurationKeys.MODULE_ID, value)
             OPTION_LOG_SEVERITY -> configuration.put(KoinConfigurationKeys.LOG_SEVERITY, value)
             OPTION_VERSION_CHECK_SEVERITY -> configuration.put(KoinConfigurationKeys.VERSION_CHECK_SEVERITY, value)
+            OPTION_JSR330 -> configuration.put(KoinConfigurationKeys.JSR330, value.toBoolean())
             else -> error("Unexpected config option: '${option.optionName}'")
         }
     }

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinPluginComponentRegistrar.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinPluginComponentRegistrar.kt
@@ -96,6 +96,7 @@ object KoinPluginLogger {
         val lookupTracker: LookupTracker? = null,
         val logSeverity: KoinLogSeverity = KoinLogSeverity.WARNING,
         val versionCheckSeverity: KoinLogSeverity = KoinLogSeverity.WARNING,
+        val jsr330: Boolean = true,
     )
 
     private val threadFlags: InheritableThreadLocal<Flags?> = InheritableThreadLocal()
@@ -112,6 +113,7 @@ object KoinPluginLogger {
     val skipDefaultValuesEnabled: Boolean get() = effectiveFlags.skipDefaultValues
     val compileSafetyEnabled: Boolean get() = effectiveFlags.compileSafety
     val aiAssistEnabled: Boolean get() = effectiveFlags.aiAssist
+    val jsr330Enabled: Boolean get() = effectiveFlags.jsr330
 
     /**
      * Compiler severity to use for [user]/[debug]/[userFir]/[debugFir]/[warn] — the plugin's
@@ -208,7 +210,7 @@ object KoinPluginLogger {
      * stay scoped) and to the volatile fallback (for callers reached outside the compilation
      * thread group — primarily the legacy [KoinPluginMessageCollector] alias).
      */
-    fun init(collector: MessageCollector, userLogs: Boolean, debugLogs: Boolean, unsafeDslChecks: Boolean = true, skipDefaultValues: Boolean = true, compileSafety: Boolean = true, aiAssist: Boolean = true, moduleId: String? = null, lookupTracker: LookupTracker? = null, logSeverity: KoinLogSeverity = KoinLogSeverity.WARNING, versionCheckSeverity: KoinLogSeverity = KoinLogSeverity.WARNING) {
+    fun init(collector: MessageCollector, userLogs: Boolean, debugLogs: Boolean, unsafeDslChecks: Boolean = true, skipDefaultValues: Boolean = true, compileSafety: Boolean = true, aiAssist: Boolean = true, moduleId: String? = null, lookupTracker: LookupTracker? = null, logSeverity: KoinLogSeverity = KoinLogSeverity.WARNING, versionCheckSeverity: KoinLogSeverity = KoinLogSeverity.WARNING, jsr330: Boolean = true) {
         threadCollector.set(collector)
         fallbackCollector = collector
         val flags = Flags(
@@ -222,6 +224,7 @@ object KoinPluginLogger {
             lookupTracker = lookupTracker,
             logSeverity = logSeverity,
             versionCheckSeverity = versionCheckSeverity,
+            jsr330 = jsr330,
         )
         threadFlags.set(flags)
         fallbackFlags = flags
@@ -390,12 +393,13 @@ class KoinPluginComponentRegistrar: CompilerPluginRegistrar() {
         val moduleId = configuration.get(KoinConfigurationKeys.MODULE_ID)
         val logSeverity = KoinLogSeverity.parse(configuration.get(KoinConfigurationKeys.LOG_SEVERITY))
         val versionCheckSeverity = KoinLogSeverity.parse(configuration.get(KoinConfigurationKeys.VERSION_CHECK_SEVERITY))
+        val jsr330 = configuration.get(KoinConfigurationKeys.JSR330, true)
 
         // IC trackers for incremental compilation support
         val lookupTracker = configuration.get(CommonConfigurationKeys.LOOKUP_TRACKER)
 
         // Initialize the centralized logger (includes lookupTracker for FIR-level IC recording)
-        KoinPluginLogger.init(messageCollector, userLogs, debugLogs, unsafeDslChecks, skipDefaultValues, compileSafety, aiAssist, moduleId, lookupTracker, logSeverity, versionCheckSeverity)
+        KoinPluginLogger.init(messageCollector, userLogs, debugLogs, unsafeDslChecks, skipDefaultValues, compileSafety, aiAssist, moduleId, lookupTracker, logSeverity, versionCheckSeverity, jsr330)
         val expectActualTracker = configuration.get(
             CommonConfigurationKeys.EXPECT_ACTUAL_TRACKER,
             ExpectActualTracker.DoNothing

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinPluginConstants.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/KoinPluginConstants.kt
@@ -87,6 +87,9 @@ object KoinPluginConstants {
      */
     const val OPTION_VERSION_CHECK_SEVERITY = "versionCheckSeverity"
 
+    /** Option to enable processing of jakarta.inject.* / javax.inject.* (JSR-330) annotations. */
+    const val OPTION_JSR330 = "jsr330"
+
     /**
      * URL printed in the AI-assist CTA.
      *

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/fir/KoinModuleFirGenerator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/fir/KoinModuleFirGenerator.kt
@@ -448,12 +448,10 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
      */
     private fun extractQualifierNameFromAnnotations(annotations: List<FirAnnotationCall>): String? {
         // Check for @Named("x")
+        val namedFqNames = KoinAnnotationFqNames.namedAnnotationFqNames(KoinPluginLogger.jsr330Enabled)
         val namedAnnotation = annotations.firstOrNull { annotation ->
             val annotationClassId = annotation.annotationTypeRef.coneTypeOrNull?.classId
-            val fqName = annotationClassId?.asSingleFqName()
-            fqName == KoinAnnotationFqNames.NAMED ||
-            fqName == KoinAnnotationFqNames.JAKARTA_NAMED ||
-            fqName == KoinAnnotationFqNames.JAVAX_NAMED
+            annotationClassId?.asSingleFqName() in namedFqNames
         }
         if (namedAnnotation != null) {
             val value = extractStringArgument(namedAnnotation)
@@ -472,6 +470,12 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
 
         return null
     }
+
+    /** True if [classSymbol] (an annotation class) is meta-annotated with Koin's own `@Qualifier`. */
+    private fun hasKoinQualifierMetaAnnotation(classSymbol: FirClassSymbol<*>): Boolean =
+        classSymbol.fir.annotations.filterIsInstance<FirAnnotationCall>().any { annotation ->
+            annotation.annotationTypeRef.coneTypeOrNull?.classId?.asSingleFqName() == KoinAnnotationFqNames.QUALIFIER
+        }
 
     private fun extractQualifierName(functionSymbol: FirNamedFunctionSymbol): String? =
         extractQualifierNameFromAnnotations(functionSymbol.fir.annotations.filterIsInstance<FirAnnotationCall>())
@@ -1147,16 +1151,18 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
         collectDefinitions(activityScopePredicate, DEF_TYPE_SCOPED)
         collectDefinitions(activityRetainedScopePredicate, DEF_TYPE_SCOPED)
         collectDefinitions(fragmentScopePredicate, DEF_TYPE_SCOPED)
-        // JSR-330 annotations - class-level @Singleton
-        collectDefinitions(jakartaSingletonPredicate, DEF_TYPE_SINGLE)
-        collectDefinitions(javaxSingletonPredicate, DEF_TYPE_SINGLE)
-        // JSR-330: class-level @Inject
-        collectDefinitions(jakartaInjectPredicate, DEF_TYPE_FACTORY)
-        collectDefinitions(javaxInjectPredicate, DEF_TYPE_FACTORY)
+        if (KoinPluginLogger.jsr330Enabled) {
+            // JSR-330 annotations - class-level @Singleton
+            collectDefinitions(jakartaSingletonPredicate, DEF_TYPE_SINGLE)
+            collectDefinitions(javaxSingletonPredicate, DEF_TYPE_SINGLE)
+            // JSR-330: class-level @Inject
+            collectDefinitions(jakartaInjectPredicate, DEF_TYPE_FACTORY)
+            collectDefinitions(javaxInjectPredicate, DEF_TYPE_FACTORY)
 
-        // Find classes with @Inject constructor (annotation on constructor, not class)
-        // FIR predicates can't match constructor annotations, so we use PSI-based scanning
-        collectInjectConstructorClasses(definitions)
+            // Find classes with @Inject constructor (annotation on constructor, not class)
+            // FIR predicates can't match constructor annotations, so we use PSI-based scanning
+            collectInjectConstructorClasses(definitions)
+        }
 
         log { "Found ${definitions.size} orphan definition classes (need hints for cross-module discovery)" }
         definitions
@@ -1331,7 +1337,10 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
             .filterIsInstance<FirRegularClassSymbol>()
             .filter { classSymbol ->
                 classSymbol.classKind == org.jetbrains.kotlin.descriptors.ClassKind.ANNOTATION_CLASS &&
-                !classSymbol.rawStatus.isExpect
+                !classSymbol.rawStatus.isExpect &&
+                // qualifierAnnotationPredicate also matches jakarta/javax @Qualifier meta-annotations;
+                // exclude those here when jsr330 is disabled instead of splitting the predicate.
+                (KoinPluginLogger.jsr330Enabled || hasKoinQualifierMetaAnnotation(classSymbol))
             }
             .forEach { classSymbol ->
                 val containingFileName = getContainingFileName(classSymbol)
@@ -1558,15 +1567,19 @@ class KoinModuleFirGenerator(session: FirSession) : FirDeclarationGenerationExte
         register(activityScopePredicate)
         register(activityRetainedScopePredicate)
         register(fragmentScopePredicate)
-        // JSR-330 predicates
-        register(jakartaSingletonPredicate)
-        register(jakartaInjectPredicate)
-        register(javaxSingletonPredicate)
-        register(javaxInjectPredicate)
-        // Custom qualifier annotation discovery (for cross-module @Qualifier meta-annotation)
+        if (KoinPluginLogger.jsr330Enabled) {
+            // JSR-330 predicates
+            register(jakartaSingletonPredicate)
+            register(jakartaInjectPredicate)
+            register(javaxSingletonPredicate)
+            register(javaxInjectPredicate)
+            // Catch-all for @Inject constructor discovery (needed for modules with only @Inject constructor classes)
+            register(anyClassPredicate)
+        }
+        // Custom qualifier annotation discovery (for cross-module @Qualifier meta-annotation).
+        // Always registered — also covers Koin's own @Qualifier meta-annotation; jsr330-only
+        // matches are filtered out at the consumption site (qualifierAnnotationInfos).
         register(qualifierAnnotationPredicate)
-        // Catch-all for @Inject constructor discovery (needed for modules with only @Inject constructor classes)
-        register(anyClassPredicate)
         // Note: We can't trigger hint discovery here because symbolNamesProvider isn't ready yet
     }
 

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/CallSiteValidator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/CallSiteValidator.kt
@@ -106,9 +106,14 @@ class CallSiteValidator(private val context: IrPluginContext) {
 
         // Also check for definition annotations on the target class (heuristic when no graph)
         val definitionAnnotationFqNames: Set<String> by lazy {
-            (org.koin.compiler.plugin.KoinAnnotationFqNames.KOIN_DEFINITION_ANNOTATIONS.map { it.asString() } +
-                org.koin.compiler.plugin.KoinAnnotationFqNames.JAKARTA_SINGLETON.asString() +
-                org.koin.compiler.plugin.KoinAnnotationFqNames.JAVAX_SINGLETON.asString()).toSet()
+            val base = org.koin.compiler.plugin.KoinAnnotationFqNames.KOIN_DEFINITION_ANNOTATIONS.map { it.asString() }
+            if (KoinPluginLogger.jsr330Enabled) {
+                (base +
+                    org.koin.compiler.plugin.KoinAnnotationFqNames.JAKARTA_SINGLETON.asString() +
+                    org.koin.compiler.plugin.KoinAnnotationFqNames.JAVAX_SINGLETON.asString()).toSet()
+            } else {
+                base.toSet()
+            }
         }
 
         // Collect unresolved call sites for deferred validation via hints

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DefinitionCallBuilder.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DefinitionCallBuilder.kt
@@ -142,14 +142,16 @@ class DefinitionCallBuilder(
      */
     private fun findConstructorToUse(targetClass: IrClass): IrConstructor? {
         // Look for @Inject annotated constructor (JSR-330 - jakarta.inject or javax.inject)
-        val injectConstructor = targetClass.declarations
-            .filterIsInstance<IrConstructor>()
-            .firstOrNull { constructor ->
-                constructor.annotations.any { annotation ->
-                    val fqName = annotation.type.classFqName?.asString()
-                    fqName == jakartaInjectFqName.asString() || fqName == javaxInjectFqName.asString()
+        val injectConstructor = if (KoinPluginLogger.jsr330Enabled) {
+            targetClass.declarations
+                .filterIsInstance<IrConstructor>()
+                .firstOrNull { constructor ->
+                    constructor.annotations.any { annotation ->
+                        val fqName = annotation.type.classFqName?.asString()
+                        fqName == jakartaInjectFqName.asString() || fqName == javaxInjectFqName.asString()
+                    }
                 }
-            }
+        } else null
 
         return injectConstructor ?: targetClass.primaryConstructor
     }

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinAnnotationProcessor.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/KoinAnnotationProcessor.kt
@@ -387,10 +387,10 @@ class KoinAnnotationProcessor(
             declaration.hasAnnotation(KoinAnnotationFqNames.ACTIVITY_SCOPE) -> "ActivityScope"
             declaration.hasAnnotation(KoinAnnotationFqNames.ACTIVITY_RETAINED_SCOPE) -> "ActivityRetainedScope"
             declaration.hasAnnotation(KoinAnnotationFqNames.FRAGMENT_SCOPE) -> "FragmentScope"
-            declaration.hasAnnotation(KoinAnnotationFqNames.JAKARTA_SINGLETON) -> "jakarta.inject.Singleton"
-            declaration.hasAnnotation(KoinAnnotationFqNames.JAKARTA_INJECT) -> "jakarta.inject.Inject"
-            declaration.hasAnnotation(KoinAnnotationFqNames.JAVAX_SINGLETON) -> "javax.inject.Singleton"
-            declaration.hasAnnotation(KoinAnnotationFqNames.JAVAX_INJECT) -> "javax.inject.Inject"
+            KoinPluginLogger.jsr330Enabled && declaration.hasAnnotation(KoinAnnotationFqNames.JAKARTA_SINGLETON) -> "jakarta.inject.Singleton"
+            KoinPluginLogger.jsr330Enabled && declaration.hasAnnotation(KoinAnnotationFqNames.JAKARTA_INJECT) -> "jakarta.inject.Inject"
+            KoinPluginLogger.jsr330Enabled && declaration.hasAnnotation(KoinAnnotationFqNames.JAVAX_SINGLETON) -> "javax.inject.Singleton"
+            KoinPluginLogger.jsr330Enabled && declaration.hasAnnotation(KoinAnnotationFqNames.JAVAX_INJECT) -> "javax.inject.Inject"
             // JSR-330: @Inject on constructor
             declaration is IrClass && hasInjectConstructor(declaration) -> "Inject constructor"
             else -> null
@@ -492,12 +492,11 @@ class KoinAnnotationProcessor(
             declaration.hasAnnotation(KoinAnnotationFqNames.ACTIVITY_SCOPE) -> DefinitionType.SCOPED
             declaration.hasAnnotation(KoinAnnotationFqNames.ACTIVITY_RETAINED_SCOPE) -> DefinitionType.SCOPED
             declaration.hasAnnotation(KoinAnnotationFqNames.FRAGMENT_SCOPE) -> DefinitionType.SCOPED
-            // JSR-330 annotations (jakarta.inject)
-            declaration.hasAnnotation(KoinAnnotationFqNames.JAKARTA_SINGLETON) -> DefinitionType.SINGLE
-            declaration.hasAnnotation(KoinAnnotationFqNames.JAKARTA_INJECT) -> DefinitionType.FACTORY // @Inject on class generates factory
-            // JSR-330 annotations (javax.inject) - legacy package
-            declaration.hasAnnotation(KoinAnnotationFqNames.JAVAX_SINGLETON) -> DefinitionType.SINGLE
-            declaration.hasAnnotation(KoinAnnotationFqNames.JAVAX_INJECT) -> DefinitionType.FACTORY // @Inject on class generates factory
+            // JSR-330 annotations (jakarta.inject and javax.inject)
+            KoinPluginLogger.jsr330Enabled &&
+                (declaration.hasAnnotation(KoinAnnotationFqNames.JAKARTA_SINGLETON) || declaration.hasAnnotation(KoinAnnotationFqNames.JAVAX_SINGLETON)) -> DefinitionType.SINGLE
+            KoinPluginLogger.jsr330Enabled &&
+                (declaration.hasAnnotation(KoinAnnotationFqNames.JAKARTA_INJECT) || declaration.hasAnnotation(KoinAnnotationFqNames.JAVAX_INJECT)) -> DefinitionType.FACTORY // @Inject on class generates factory
             // JSR-330: @Inject on constructor also generates factory
             declaration is IrClass && hasInjectConstructor(declaration) -> DefinitionType.FACTORY
             else -> null
@@ -508,6 +507,7 @@ class KoinAnnotationProcessor(
      * Check if the class has a constructor annotated with @Inject (jakarta.inject or javax.inject)
      */
     private fun hasInjectConstructor(irClass: IrClass): Boolean {
+        if (!KoinPluginLogger.jsr330Enabled) return false
         return irClass.declarations
             .filterIsInstance<IrConstructor>()
             .any { constructor ->

--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/QualifierExtractor.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/QualifierExtractor.kt
@@ -95,11 +95,9 @@ class QualifierExtractor(private val context: IrPluginContext) {
      */
     fun extractFromDeclaration(declaration: IrDeclaration, logContext: String? = null): QualifierValue? {
         // Check for @Named (Koin, jakarta.inject, or javax.inject)
+        val namedFqNames = KoinAnnotationFqNames.namedAnnotationFqNames(KoinPluginLogger.jsr330Enabled)
         val namedAnnotation = declaration.annotations.firstOrNull { annotation ->
-            val fqName = annotation.type.classFqName?.asString()
-            fqName == KoinAnnotationFqNames.NAMED.asString() ||
-            fqName == KoinAnnotationFqNames.JAKARTA_NAMED.asString() ||
-            fqName == KoinAnnotationFqNames.JAVAX_NAMED.asString()
+            annotation.type.classFqName in namedFqNames
         }
 
         if (namedAnnotation != null) {
@@ -164,11 +162,9 @@ class QualifierExtractor(private val context: IrPluginContext) {
      */
     fun extractFromParameter(param: IrValueParameter): QualifierValue? {
         // Check for @Named (Koin, jakarta.inject, or javax.inject)
+        val namedFqNames = KoinAnnotationFqNames.namedAnnotationFqNames(KoinPluginLogger.jsr330Enabled)
         val namedAnnotation = param.annotations.firstOrNull { annotation ->
-            val fqName = annotation.type.classFqName?.asString()
-            fqName == KoinAnnotationFqNames.NAMED.asString() ||
-            fqName == KoinAnnotationFqNames.JAKARTA_NAMED.asString() ||
-            fqName == KoinAnnotationFqNames.JAVAX_NAMED.asString()
+            annotation.type.classFqName in namedFqNames
         }
 
         if (namedAnnotation != null) {
@@ -273,20 +269,15 @@ class QualifierExtractor(private val context: IrPluginContext) {
      * than type-based resolution for cross-module deserialized annotation classes.
      */
     private fun isQualifierMetaAnnotation(metaAnnotation: IrConstructorCall): Boolean {
+        val qualifierMetaFqNames = KoinAnnotationFqNames.qualifierMetaAnnotationFqNames(KoinPluginLogger.jsr330Enabled)
         // Primary: check via type (works for same-module classes)
-        val metaFqName = metaAnnotation.type.classFqName?.asString()
+        val metaFqName = metaAnnotation.type.classFqName
         if (metaFqName != null) {
-            return metaFqName == KoinAnnotationFqNames.QUALIFIER.asString() ||
-                metaFqName == KoinAnnotationFqNames.NAMED.asString() ||
-                metaFqName == KoinAnnotationFqNames.JAKARTA_QUALIFIER.asString() ||
-                metaFqName == KoinAnnotationFqNames.JAVAX_QUALIFIER.asString()
+            return metaFqName in qualifierMetaFqNames
         }
         // Fallback: check via constructor symbol's parent class (works for cross-module deserialized classes)
-        val parentFqName = (metaAnnotation.symbol.owner.parent as? IrClass)?.fqNameWhenAvailable?.asString()
-        return parentFqName == KoinAnnotationFqNames.QUALIFIER.asString() ||
-            parentFqName == KoinAnnotationFqNames.NAMED.asString() ||
-            parentFqName == KoinAnnotationFqNames.JAKARTA_QUALIFIER.asString() ||
-            parentFqName == KoinAnnotationFqNames.JAVAX_QUALIFIER.asString()
+        val parentFqName = (metaAnnotation.symbol.owner.parent as? IrClass)?.fqNameWhenAvailable
+        return parentFqName in qualifierMetaFqNames
     }
 
     // Instance-level registry of known custom qualifier annotation FQ names

--- a/koin-compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/services/ExtensionRegistrarConfigurator.kt
+++ b/koin-compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/services/ExtensionRegistrarConfigurator.kt
@@ -57,6 +57,7 @@ class CapturingMessageCollector(private val delegate: MessageCollector) : Messag
 
 fun TestConfigurationBuilder.configurePlugin() {
     useConfigurators(::ExtensionRegistrarConfigurator)
+    useDirectives(KoinTestDirectives)
     configureAnnotations()
 }
 
@@ -67,10 +68,11 @@ private class ExtensionRegistrarConfigurator(testServices: TestServices) : Envir
     ) {
         val rawCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
         val messageCollector = CapturingMessageCollector(rawCollector)
+        val jsr330 = KoinTestDirectives.JSR330_DISABLED !in module.directives
         // Initialize the logger for tests (enable both user and debug logs).
         // Disable aiAssist so golden `.errors.txt` files exercise diagnostic content only,
         // not the trailing CTA banner — the CTA has its own coverage in KoinDiagnosticTest.
-        KoinPluginLogger.init(messageCollector, userLogs = true, debugLogs = true, compileSafety = true, aiAssist = false)
+        KoinPluginLogger.init(messageCollector, userLogs = true, debugLogs = true, compileSafety = true, aiAssist = false, jsr330 = jsr330)
         FirExtensionRegistrarAdapter.registerExtension(KoinPluginRegistrar())
         IrGenerationExtension.registerExtension(KoinIrExtension(lookupTracker = null, expectActualTracker = org.jetbrains.kotlin.incremental.components.ExpectActualTracker.DoNothing, messageCollector = messageCollector, flagsHandle = KoinPluginLogger.captureFlags()))
     }

--- a/koin-compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/services/KoinTestDirectives.kt
+++ b/koin-compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/services/KoinTestDirectives.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.kotlin.compiler.plugin.template.services
+
+import org.jetbrains.kotlin.test.directives.model.SimpleDirectivesContainer
+
+/**
+ * Custom test directives for exercising Koin compiler plugin options that aren't exposed
+ * any other way from `testData/box` sources (which have no `build.gradle.kts` to configure).
+ */
+object KoinTestDirectives : SimpleDirectivesContainer() {
+    /** `// JSR330_DISABLED` — runs the test with `jsr330 = false` (see [KoinTestDirectives]). */
+    val JSR330_DISABLED by directive(
+        "Disables jakarta.inject/javax.inject (JSR-330) annotation processing for this test"
+    )
+}

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -160,6 +160,28 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
   }
 
   @Nested
+  @TestMetadata("koin-compiler-plugin/testData/box/jsr330")
+  @TestDataPath("$PROJECT_ROOT")
+  public class Jsr330 {
+    @Test
+    public void testAllFilesPresentInJsr330() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/jsr330"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("jsr330_disabled_skips_processing.kt")
+    public void testJsr330_disabled_skips_processing() {
+      runTest("koin-compiler-plugin/testData/box/jsr330/jsr330_disabled_skips_processing.kt");
+    }
+
+    @Test
+    @TestMetadata("jsr330_singleton_enabled_by_default.kt")
+    public void testJsr330_singleton_enabled_by_default() {
+      runTest("koin-compiler-plugin/testData/box/jsr330/jsr330_singleton_enabled_by_default.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("koin-compiler-plugin/testData/box/modules")
   @TestDataPath("$PROJECT_ROOT")
   public class Modules {

--- a/koin-compiler-plugin/test/org/koin/compiler/plugin/KoinJsr330Test.kt
+++ b/koin-compiler-plugin/test/org/koin/compiler/plugin/KoinJsr330Test.kt
@@ -1,0 +1,45 @@
+package org.koin.compiler.plugin
+
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the `jsr330` knob round-trips through [KoinPluginLogger]: default `true`
+ * (preserves prior behavior — jakarta.inject/javax.inject processed), explicit `false`
+ * flips [KoinPluginLogger.jsr330Enabled].
+ *
+ * `@Isolated` for the same reason as [KoinLogSeverityTest]: [KoinPluginLogger] is a
+ * process-wide singleton.
+ */
+@Isolated
+class KoinJsr330Test {
+
+    @AfterEach
+    fun restoreLoggerDefaults() {
+        KoinPluginLogger.init(
+            collector = MessageCollector.NONE,
+            userLogs = false,
+            debugLogs = false,
+            unsafeDslChecks = true,
+            skipDefaultValues = true,
+            compileSafety = true,
+            aiAssist = false,
+        )
+    }
+
+    @Test
+    fun `jsr330 defaults to true (preserves prior behavior)`() {
+        KoinPluginLogger.init(MessageCollector.NONE, userLogs = false, debugLogs = false, aiAssist = false)
+        assertTrue(KoinPluginLogger.jsr330Enabled)
+    }
+
+    @Test
+    fun `jsr330 = false disables the flag`() {
+        KoinPluginLogger.init(MessageCollector.NONE, userLogs = false, debugLogs = false, aiAssist = false, jsr330 = false)
+        assertFalse(KoinPluginLogger.jsr330Enabled)
+    }
+}

--- a/koin-compiler-plugin/testData/box/jsr330/jsr330_disabled_skips_processing.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/jsr330/jsr330_disabled_skips_processing.fir.ir.txt
@@ -1,0 +1,82 @@
+FILE fqName:<root> fileName:/test.kt
+  CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Singleton
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Service
+    CONSTRUCTOR visibility:public returnType:<root>.Service [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestModule
+    CONSTRUCTOR visibility:public returnType:<root>.TestModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: CALL 'public final fun module (<this>: <root>.TestModule): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=null
+                        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TestModule' type=<root>.TestModule origin=null
+      VAR name:service type:<root>.Service? [val]
+        CALL 'public final fun getOrNull <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.getOrNull? declared in org.koin.core.Koin' type=<root>.Service? origin=null
+          TYPE_ARG T: <root>.Service
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              ARG arg0: GET_VAR 'val service: <root>.Service? declared in <root>.box' type=<root>.Service? origin=null
+              ARG arg1: CONST Null type=kotlin.Nothing? value=null
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CONST String type=kotlin.String value="FAIL: jakarta.inject.Singleton was processed despite jsr330 = false"
+FILE fqName:<root> fileName:/testModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.TestModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: <root>.TestModule): org.koin.core.module.Module declared in <root>'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY

--- a/koin-compiler-plugin/testData/box/jsr330/jsr330_disabled_skips_processing.fir.txt
+++ b/koin-compiler-plugin/testData/box/jsr330/jsr330_disabled_skips_processing.fir.txt
@@ -1,0 +1,31 @@
+FILE: test.kt
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|() public final class TestModule : R|kotlin/Any| {
+        public constructor(): R|TestModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|jakarta/inject/Singleton|() public final class Service : R|kotlin/Any| {
+        public constructor(): R|Service| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/TestModule.TestModule|().R|/module|())
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval service: R|Service?| = R|<local>/koin|.R|org/koin/core/Koin.getOrNull|<R|Service|>()
+        ^box when () {
+            ==(R|<local>/service|, Null(null)) ->  {
+                String(OK)
+            }
+            else ->  {
+                String(FAIL: jakarta.inject.Singleton was processed despite jsr330 = false)
+            }
+        }
+
+    }
+FILE: /testModuleModule.kt
+    public final fun R|TestModule|.module(): R|org/koin/core/module/Module|

--- a/koin-compiler-plugin/testData/box/jsr330/jsr330_disabled_skips_processing.kt
+++ b/koin-compiler-plugin/testData/box/jsr330/jsr330_disabled_skips_processing.kt
@@ -1,0 +1,24 @@
+// JSR330_DISABLED
+// FILE: test.kt
+import org.koin.dsl.koinApplication
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.ComponentScan
+
+// With jsr330 = false, jakarta.inject.Singleton must NOT be recognized as a Koin definition
+// annotation — the class is silently skipped, not registered under any type.
+@Module
+@ComponentScan
+class TestModule
+
+@jakarta.inject.Singleton
+class Service
+
+fun box(): String {
+    val koin = koinApplication {
+        modules(TestModule().module())
+    }.koin
+
+    val service = koin.getOrNull<Service>()
+
+    return if (service == null) "OK" else "FAIL: jakarta.inject.Singleton was processed despite jsr330 = false"
+}

--- a/koin-compiler-plugin/testData/box/jsr330/jsr330_singleton_enabled_by_default.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/jsr330/jsr330_singleton_enabled_by_default.fir.ir.txt
@@ -1,0 +1,101 @@
+FILE fqName:org.koin.plugin.hints fileName:/koin_hints_TestModule_8cd674464db476dd.kt
+  FUN name:componentscan_testModule_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Service
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:<root> fileName:/test.kt
+  CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Singleton
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Service
+    CONSTRUCTOR visibility:public returnType:<root>.Service [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestModule
+    CONSTRUCTOR visibility:public returnType:<root>.TestModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TestModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun koinApplication (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>?): org.koin.core.KoinApplication declared in org.koin.dsl' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$koinApplication index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$koinApplication: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: CALL 'public final fun module (<this>: <root>.TestModule): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=null
+                        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TestModule' type=<root>.TestModule origin=null
+      VAR name:service type:<root>.Service? [val]
+        CALL 'public final fun getOrNull <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.getOrNull? declared in org.koin.core.Koin' type=<root>.Service? origin=null
+          TYPE_ARG T: <root>.Service
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_VAR 'val service: <root>.Service? declared in <root>.box' type=<root>.Service? origin=null
+                ARG arg1: CONST Null type=kotlin.Nothing? value=null
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CONST String type=kotlin.String value="FAIL: jakarta.inject.Singleton was not processed by default"
+FILE fqName:<root> fileName:/testModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.TestModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: <root>.TestModule): org.koin.core.module.Module declared in <root>'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                  TYPE_ARG T: <root>.Service
+                  ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                  ARG kclass: CLASS_REFERENCE 'CLASS CLASS name:Service modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Service>
+                  ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.Service> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.Service
+                      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                      VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.Service declared in <root>.module.<anonymous>'
+                          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.Service' type=<root>.Service origin=null

--- a/koin-compiler-plugin/testData/box/jsr330/jsr330_singleton_enabled_by_default.fir.txt
+++ b/koin-compiler-plugin/testData/box/jsr330/jsr330_singleton_enabled_by_default.fir.txt
@@ -1,0 +1,31 @@
+FILE: test.kt
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|() public final class TestModule : R|kotlin/Any| {
+        public constructor(): R|TestModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|jakarta/inject/Singleton|() public final class Service : R|kotlin/Any| {
+        public constructor(): R|Service| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/dsl/koinApplication|(<L> = koinApplication@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/TestModule.TestModule|().R|/module|())
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval service: R|Service?| = R|<local>/koin|.R|org/koin/core/Koin.getOrNull|<R|Service|>()
+        ^box when () {
+            !=(R|<local>/service|, Null(null)) ->  {
+                String(OK)
+            }
+            else ->  {
+                String(FAIL: jakarta.inject.Singleton was not processed by default)
+            }
+        }
+
+    }
+FILE: /testModuleModule.kt
+    public final fun R|TestModule|.module(): R|org/koin/core/module/Module|

--- a/koin-compiler-plugin/testData/box/jsr330/jsr330_singleton_enabled_by_default.kt
+++ b/koin-compiler-plugin/testData/box/jsr330/jsr330_singleton_enabled_by_default.kt
@@ -1,0 +1,24 @@
+// FILE: test.kt
+import org.koin.dsl.koinApplication
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.ComponentScan
+
+// Baseline: jakarta.inject.Singleton is processed like @Singleton when jsr330 is left at its
+// default (true). Establishes the RED case for jsr330_disabled_skips_processing.kt: without the
+// jsr330 gate, this class is always registered — with it, it must stay registered by default.
+@Module
+@ComponentScan
+class TestModule
+
+@jakarta.inject.Singleton
+class Service
+
+fun box(): String {
+    val koin = koinApplication {
+        modules(TestModule().module())
+    }.koin
+
+    val service = koin.getOrNull<Service>()
+
+    return if (service != null) "OK" else "FAIL: jakarta.inject.Singleton was not processed by default"
+}


### PR DESCRIPTION
## Summary

Add a `jsr330` option to `koinCompiler { }` (default: `true`) that controls whether `jakarta.inject.*`/`javax.inject.*` (JSR-330) annotations are recognized alongside Koin's own. Setting `jsr330 = false` disables JSR-330 recognition entirely — only `org.koin.core.annotation.*` annotations are processed.

## Changes

- **Option plumbing**: `KoinGradleExtension` → Gradle subplugin option → `KoinCommandLineProcessor` → `KoinPluginComponentRegistrar` → `KoinPluginLogger.jsr330Enabled` (same pattern as existing boolean flags).
- **Skip logic**: gated every JSR-330 recognition point behind the flag — FIR orphan-class discovery, predicate registration, `@Inject`-constructor PSI scan; IR definition-type detection, constructor selection, qualifier extraction, A4 call-site heuristic.
- **De-duplication**: centralized the two FqName sets (`@Named`-family, qualifier-meta-family) that were re-derived identically at 3+ call sites into `KoinAnnotationFqNames.namedAnnotationFqNames()` / `qualifierMetaAnnotationFqNames()`.
- **Docs**: `jsr330` documented in `CLAUDE.md` and `README.md`.

## Behavior

Default (`true`) preserves current behavior exactly — no existing golden files changed. `false` is purely opt-in and additive: no removals, no signature changes.

## Test plan

- [x] `KoinJsr330Test` — flag round-trips to `KoinPluginLogger.jsr330Enabled` (default true / explicit false)
- [x] New `// JSR330_DISABLED` box-test directive, wired through `ExtensionRegistrarConfigurator` (testData/box has no `build.gradle.kts` to configure the Gradle extension otherwise)
- [x] `jsr330_singleton_enabled_by_default.kt` — baseline, `jakarta.inject.Singleton` resolves
- [x] `jsr330_disabled_skips_processing.kt` — same class returns `null` from `getOrNull<T>()` with the flag off
- [x] Confirmed RED before GREEN: reverted one gate, watched the disabled test fail, restored
- [x] Full `:koin-compiler-plugin:test` suite green, no golden-file diffs elsewhere

## Manual verification (playground-apps/app-annotations)

Real-world reproduction, since `jsr330=false` only has an observable effect on a class defined
*purely* via JSR-330 (no Koin annotation) — every existing `jakarta.inject`/`javax.inject` usage
in the playground apps also carries `@Singleton`, so it doesn't exercise the flag on its own.

1. `./install.sh` from repo root (publishes the plugin to Maven local under `pluginVersion`).
2. Bump `playground-apps/app-annotations/gradle/libs.versions.toml`'s `koin-plugin` to match.
3. Apply the patch below, then `./gradlew :core:datastore:compileDebugKotlin`.

Expected: `JsrOnlyService` is JSR-330-only. With `jsr330 = false`, it stops being a definition,
so `Consumer`'s dependency on it goes unresolved — the build **must fail with `KOIN-D001`**
(missing dependency). Flip `jsr330` back to `true` (or remove the line) and the same build
**must pass**, confirming the gate is what's causing the failure, not something else.

```diff
diff --git a/playground-apps/app-annotations/core/datastore/build.gradle.kts b/playground-apps/app-annotations/core/datastore/build.gradle.kts
index f5076b2..024f6ff 100644
--- a/playground-apps/app-annotations/core/datastore/build.gradle.kts
+++ b/playground-apps/app-annotations/core/datastore/build.gradle.kts
@@ -17,6 +17,7 @@ android {
 koinCompiler {
     userLogs = true
     debugLogs = true
+    jsr330 = false
 }
 
 dependencies {
diff --git a/playground-apps/app-annotations/core/datastore/src/main/kotlin/org/koin/sample/datastore/UserPreferencesDataSource.kt b/playground-apps/app-annotations/core/datastore/src/main/kotlin/org/koin/sample/datastore/UserPreferencesDataSource.kt
index 8d1701b..0c3b822 100644
--- a/playground-apps/app-annotations/core/datastore/src/main/kotlin/org/koin/sample/datastore/UserPreferencesDataSource.kt
+++ b/playground-apps/app-annotations/core/datastore/src/main/kotlin/org/koin/sample/datastore/UserPreferencesDataSource.kt
@@ -5,14 +5,21 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import jakarta.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import jakarta.inject.Inject
 import org.koin.core.annotation.Singleton
 import org.koin.sample.model.UserData
 
+@jakarta.inject.Singleton
+class JsrOnlyService
+
+@Singleton
+class Consumer(val svc: JsrOnlyService)
+
 @Singleton
 class UserPreferencesDataSource @Inject constructor(
+    private val consumer: Consumer,
     private val dataStore: DataStore<Preferences>,
 ) {
     private val bookmarkedNewsIds = stringSetPreferencesKey("bookmarked_news_ids")
```