### PR TITLE
fix(safety): exclude providerOnly DSL defs from full-graph consumer validation

### DIFF
--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/CompileSafetyValidator.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/CompileSafetyValidator.kt
@@ -130,11 +130,19 @@ class CompileSafetyValidator(
         KoinPluginLogger.debug { "  graph summary: ${allDefinitions.size} total providers/consumers, from ${allModuleIrClasses.size} modules" }
         KoinPluginLogger.debug { "  -> VALIDATING..." }
 
+        // providerOnly DSL defs (lambda-body singles, create(::fn) calls) must remain in
+        // allDefinitions so their bound type is registered as provided, but they must not be
+        // validated as consumers — the plugin never calls their bound type's constructor, so its
+        // constructor parameters are not requirements (#83). Mirror the filter that
+        // CallSiteValidator uses for its Phase 3.1 path.
+        val definitionsToValidate = allDefinitions.filter { !(it is Definition.DslDef && it.providerOnly) }
+
         val fullGraphRegistry = BindingRegistry()
         val errorCount = fullGraphRegistry.validateModule(
             appName,
             allDefinitions,
             qualifierExtractor,
+            definitionsToValidate,
             reportedCycles = reportedCycles,
             reportedMissingDeps = reportedMissingDeps,
         )

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -123,6 +123,12 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     }
 
     @Test
+    @TestMetadata("provider_only_no_false_d001.kt")
+    public void testProvider_only_no_false_d001() {
+      runTest("koin-compiler-plugin/testData/box/dsl/provider_only_no_false_d001.kt");
+    }
+
+    @Test
     @TestMetadata("scoped_basic.kt")
     public void testScoped_basic() {
       runTest("koin-compiler-plugin/testData/box/dsl/scoped_basic.kt");

--- a/koin-compiler-plugin/testData/box/dsl/provider_only_no_false_d001.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/provider_only_no_false_d001.fir.ir.txt
@@ -1,0 +1,135 @@
+FILE fqName:org.koin.plugin.hints fileName:/koin_dsl_hints_main__test_kt_06549e611b62f6c5.kt
+  FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Probe
+    VALUE_PARAMETER kind:Regular name:providerOnly index:1 type:kotlin.Unit
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+  FUN name:dsl_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.Probe
+    VALUE_PARAMETER kind:Regular name:providerOnly index:1 type:kotlin.Unit
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:<root> fileName:/test.kt
+  CLASS CLASS name:Probe modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Probe
+    PROPERTY name:a visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'a: kotlin.String declared in <root>.Probe.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Probe
+        correspondingProperty: PROPERTY name:a visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-a> (): kotlin.String declared in <root>.Probe'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Probe declared in <root>.Probe.<get-a>' type=<root>.Probe origin=null
+    PROPERTY name:b visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'b: kotlin.Int declared in <root>.Probe.<init>' type=kotlin.Int origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Probe
+        correspondingProperty: PROPERTY name:b visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-b> (): kotlin.Int declared in <root>.Probe'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Probe declared in <root>.Probe.<get-b>' type=<root>.Probe origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Probe [primary]
+      VALUE_PARAMETER kind:Regular name:a index:0 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:b index:1 type:kotlin.Int
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Probe modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun startKoin (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>): org.koin.core.KoinApplication declared in org.koin.core.context' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$startKoin index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (vararg modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$startKoin: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: VARARG type=kotlin.Array<out org.koin.core.module.Module> varargElementType=org.koin.core.module.Module
+                        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+                          ARG moduleDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+                            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                              VALUE_PARAMETER kind:ExtensionReceiver name:$this$module index:0 type:org.koin.core.module.Module
+                              BLOCK_BODY
+                                TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                                  CALL 'public final fun single <T> (qualifier: org.koin.core.qualifier.Qualifier?, createdAtStart: kotlin.Boolean, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.core.module.Module.single>): org.koin.core.definition.KoinDefinition<T of org.koin.core.module.Module.single> declared in org.koin.core.module.Module' type=org.koin.core.definition.KoinDefinition<<root>.Probe> origin=null
+                                    TYPE_ARG T: <root>.Probe
+                                    ARG <this>: GET_VAR '$this$module: org.koin.core.module.Module declared in <root>.box.<anonymous>.<anonymous>' type=org.koin.core.module.Module origin=IMPLICIT_ARGUMENT
+                                    ARG definition: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.Probe> origin=LAMBDA
+                                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.Probe
+                                        VALUE_PARAMETER kind:ExtensionReceiver name:$this$single index:0 type:org.koin.core.scope.Scope
+                                        VALUE_PARAMETER kind:Regular name:it index:1 type:org.koin.core.parameter.ParametersHolder
+                                        BLOCK_BODY
+                                          RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$single: org.koin.core.scope.Scope, it: org.koin.core.parameter.ParametersHolder): <root>.Probe declared in <root>.box.<anonymous>.<anonymous>'
+                                            CONSTRUCTOR_CALL 'public constructor <init> (a: kotlin.String, b: kotlin.Int) declared in <root>.Probe' type=<root>.Probe origin=null
+                                              ARG a: CONST String type=kotlin.String value="x"
+                                              ARG b: CONST Int type=kotlin.Int value=1
+                        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+                          ARG moduleDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+                            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                              VALUE_PARAMETER kind:ExtensionReceiver name:$this$module index:0 type:org.koin.core.module.Module
+                              BLOCK_BODY
+                                TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                                  CALL 'public final fun single <T> (qualifier: org.koin.core.qualifier.Qualifier?, createdAtStart: kotlin.Boolean, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.core.module.Module.single>): org.koin.core.definition.KoinDefinition<T of org.koin.core.module.Module.single> declared in org.koin.core.module.Module' type=org.koin.core.definition.KoinDefinition<<root>.Probe> origin=null
+                                    TYPE_ARG T: <root>.Probe
+                                    ARG <this>: GET_VAR '$this$module: org.koin.core.module.Module declared in <root>.box.<anonymous>.<anonymous>' type=org.koin.core.module.Module origin=IMPLICIT_ARGUMENT
+                                    ARG definition: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.Probe> origin=LAMBDA
+                                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.Probe
+                                        VALUE_PARAMETER kind:ExtensionReceiver name:$this$single index:0 type:org.koin.core.scope.Scope
+                                        VALUE_PARAMETER kind:Regular name:it index:1 type:org.koin.core.parameter.ParametersHolder
+                                        BLOCK_BODY
+                                          RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$single: org.koin.core.scope.Scope, it: org.koin.core.parameter.ParametersHolder): <root>.Probe declared in <root>.box.<anonymous>.<anonymous>'
+                                            CALL 'private final fun makeProbe (): <root>.Probe declared in <root>' type=<root>.Probe origin=null
+      VAR name:p1 type:<root>.Probe [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.Probe origin=null
+          TYPE_ARG T: <root>.Probe
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      CALL 'public final fun stopKoin (): kotlin.Unit declared in org.koin.core.context' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: WHEN type=kotlin.Boolean origin=ANDAND
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: CALL 'public final fun <get-a> (): kotlin.String declared in <root>.Probe' type=kotlin.String origin=GET_PROPERTY
+                    ARG <this>: GET_VAR 'val p1: <root>.Probe declared in <root>.box' type=<root>.Probe origin=null
+                  ARG arg1: CONST String type=kotlin.String value="x"
+                then: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: CALL 'public final fun <get-b> (): kotlin.Int declared in <root>.Probe' type=kotlin.Int origin=GET_PROPERTY
+                    ARG <this>: GET_VAR 'val p1: <root>.Probe declared in <root>.box' type=<root>.Probe origin=null
+                  ARG arg1: CONST Int type=kotlin.Int value=1
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CONST Boolean type=kotlin.Boolean value=false
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CONST String type=kotlin.String value="FAIL"
+  FUN name:makeProbe visibility:private modality:FINAL returnType:<root>.Probe
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun makeProbe (): <root>.Probe declared in <root>'
+        CONSTRUCTOR_CALL 'public constructor <init> (a: kotlin.String, b: kotlin.Int) declared in <root>.Probe' type=<root>.Probe origin=null
+          ARG a: CONST String type=kotlin.String value="x"
+          ARG b: CONST Int type=kotlin.Int value=1

--- a/koin-compiler-plugin/testData/box/dsl/provider_only_no_false_d001.fir.txt
+++ b/koin-compiler-plugin/testData/box/dsl/provider_only_no_false_d001.fir.txt
@@ -1,0 +1,45 @@
+FILE: test.kt
+    public final class Probe : R|kotlin/Any| {
+        public constructor(a: R|kotlin/String|, b: R|kotlin/Int|): R|Probe| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val a: R|kotlin/String| = R|<local>/a|
+            public get(): R|kotlin/String|
+
+        public final val b: R|kotlin/Int| = R|<local>/b|
+            public get(): R|kotlin/Int|
+
+    }
+    private final fun makeProbe(): R|Probe| {
+        ^makeProbe R|/Probe.Probe|(String(x), Int(1))
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/core/context/startKoin|(<L> = startKoin@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(vararg(R|org/koin/dsl/module|(<L> = module@fun R|org/koin/core/module/Module|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+                this@R|special/anonymous|.R|org/koin/core/module/Module.single|<R|Probe|>(<L> = single@fun R|org/koin/core/scope/Scope|.<anonymous>(it: R|org/koin/core/parameter/ParametersHolder|): R|Probe| <inline=NoInline>  {
+                    ^ R|/Probe.Probe|(String(x), Int(1))
+                }
+                )
+            }
+            ), R|org/koin/dsl/module|(<L> = module@fun R|org/koin/core/module/Module|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+                this@R|special/anonymous|.R|org/koin/core/module/Module.single|<R|Probe|>(<L> = single@fun R|org/koin/core/scope/Scope|.<anonymous>(it: R|org/koin/core/parameter/ParametersHolder|): R|Probe| <inline=NoInline>  {
+                    ^ R|/makeProbe|()
+                }
+                )
+            }
+            )))
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval p1: R|Probe| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|Probe|>()
+        R|org/koin/core/context/stopKoin|()
+        ^box when () {
+            ==(R|<local>/p1|.R|/Probe.a|, String(x)) && ==(R|<local>/p1|.R|/Probe.b|, Int(1)) ->  {
+                String(OK)
+            }
+            else ->  {
+                String(FAIL)
+            }
+        }
+
+    }

--- a/koin-compiler-plugin/testData/box/dsl/provider_only_no_false_d001.kt
+++ b/koin-compiler-plugin/testData/box/dsl/provider_only_no_false_d001.kt
@@ -1,0 +1,34 @@
+// FILE: test.kt
+// Regression test for #83: providerOnly DSL definitions (lambda-body singles and create(::fn)
+// calls) must not trigger KOIN-D001 for their bound type's constructor parameters. The plugin
+// never invokes that constructor — the lambda or factory function builds the instance — so those
+// parameters are not requirements.
+import org.koin.dsl.module
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+
+// Constructor parameters (String, Int) are NOT in the DI graph — intentional.
+// Before the fix, full-graph validation reported:
+//   KOIN-D001: Missing dependency: kotlin.String required by dsl:Probe (parameter 'a')
+//   KOIN-D001: Missing dependency: kotlin.Int   required by dsl:Probe (parameter 'b')
+class Probe(val a: String, val b: Int)
+
+private fun makeProbe(): Probe = Probe("x", 1)
+
+fun box(): String {
+    val koin = startKoin {
+        modules(
+            module {
+                single { Probe("x", 1) }         // lambda builds it — providerOnly
+            },
+            module {
+                single { makeProbe() }            // factory function — providerOnly
+            }
+        )
+    }.koin
+
+    val p1 = koin.get<Probe>()
+    stopKoin()
+
+    return if (p1.a == "x" && p1.b == 1) "OK" else "FAIL"
+}


### PR DESCRIPTION
fixes #83 

## Fix

Build a `definitionsToValidate` list that excludes `providerOnly` DSL defs before passing it to `BindingRegistry.validateModule`. The full `allDefinitions` list (including `providerOnly` defs) is still used as the provider set, so their bound types remain registered as provided. Only the consumer validation step is narrowed.

## Test

Added `provider_only_no_false_d001` box test: a `startKoin` compilation with a lambda-body `single` and a factory-function `single` whose bound type has constructor parameters absent from the graph. Must compile clean with no `KOIN-D001`.