### PR TITLE
fix(annotations): @Single/@Singleton on Kotlin object emits GET_OBJECT instead of constructor call

### DIFF
--- a/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DefinitionCallBuilder.kt
+++ b/koin-compiler-plugin/src/org/koin/compiler/plugin/ir/DefinitionCallBuilder.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.util.isObject
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -61,8 +62,11 @@ class DefinitionCallBuilder(
         builder: DeclarationIrBuilder
     ): IrExpression? {
         val targetClass = definition.irClass
-        val constructor = findConstructorToUse(targetClass)
-        if (constructor == null) {
+
+        // Objects have no accessible constructor — use INSTANCE reference instead.
+        val isObjectTarget = targetClass.isObject
+        val constructor = if (isObjectTarget) null else findConstructorToUse(targetClass)
+        if (!isObjectTarget && constructor == null) {
             KoinPluginLogger.debug { "No constructor found for ${targetClass.fqNameWhenAvailable} - definition skipped" }
             return null
         }
@@ -113,7 +117,11 @@ class DefinitionCallBuilder(
             val qualifierArg: IrExpression = qualifierExtractor.createQualifierCall(effectiveQualifier, builder) ?: builder.irNull()
             putRegularArgument(1, qualifierArg)
 
-            val definitionLambda = createDefinitionLambda(constructor, targetClass, builder, parentFunction)
+            val definitionLambda = if (isObjectTarget) {
+                createObjectDefinitionLambda(targetClass, builder, parentFunction)
+            } else {
+                createDefinitionLambda(constructor!!, targetClass, builder, parentFunction)
+            }
             putRegularArgument(2, definitionLambda)
 
             // Add createdAtStart parameter if applicable (only for SINGLE)
@@ -318,8 +326,10 @@ class DefinitionCallBuilder(
         builder: DeclarationIrBuilder
     ): IrExpression? {
         val targetClass = definition.irClass
-        val constructor = findConstructorToUse(targetClass)
-        if (constructor == null) {
+
+        val isObjectTarget = targetClass.isObject
+        val constructor = if (isObjectTarget) null else findConstructorToUse(targetClass)
+        if (!isObjectTarget && constructor == null) {
             KoinPluginLogger.debug { "No constructor found for scoped ${targetClass.fqNameWhenAvailable} - definition skipped" }
             return null
         }
@@ -369,7 +379,11 @@ class DefinitionCallBuilder(
             val qualifierCall = qualifierExtractor.createQualifierCall(effectiveQualifier, builder)
             putRegularArgument(1, qualifierCall ?: builder.irNull())
 
-            val definitionLambda = createDefinitionLambda(constructor, targetClass, builder, parentFunction)
+            val definitionLambda = if (isObjectTarget) {
+                createObjectDefinitionLambda(targetClass, builder, parentFunction)
+            } else {
+                createDefinitionLambda(constructor!!, targetClass, builder, parentFunction)
+            }
             putRegularArgument(2, definitionLambda)
         }
 
@@ -600,6 +614,20 @@ class DefinitionCallBuilder(
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Create a lambda expression for an object singleton: { MyObject }
+     * Objects have no constructor to call — the singleton instance is accessed via INSTANCE.
+     */
+    private fun createObjectDefinitionLambda(
+        targetClass: IrClass,
+        builder: DeclarationIrBuilder,
+        parentFunction: IrFunction
+    ): IrExpression {
+        return lambdaBuilder.create(targetClass, builder, parentFunction) { irBuilder, _, _ ->
+            irBuilder.irGetObject(targetClass.symbol)
         }
     }
 

--- a/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
+++ b/koin-compiler-plugin/test-gen/org/jetbrains/kotlin/compiler/plugin/template/runners/JvmBoxTestGenerated.java
@@ -43,6 +43,12 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     }
 
     @Test
+    @TestMetadata("object_singleton.kt")
+    public void testObject_singleton() {
+      runTest("koin-compiler-plugin/testData/box/annotations/object_singleton.kt");
+    }
+
+    @Test
     @TestMetadata("single_fun_created_at_start.kt")
     public void testSingle_fun_created_at_start() {
       runTest("koin-compiler-plugin/testData/box/annotations/single_fun_created_at_start.kt");
@@ -544,6 +550,12 @@ public class JvmBoxTestGenerated extends AbstractJvmBoxTest {
     @Test
     public void testAllFilesPresentInStartkoin() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("koin-compiler-plugin/testData/box/startkoin"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("configuration_const_val_label.kt")
+    public void testConfiguration_const_val_label() {
+      runTest("koin-compiler-plugin/testData/box/startkoin/configuration_const_val_label.kt");
     }
 
     @Test

--- a/koin-compiler-plugin/testData/box/annotations/object_singleton.fir.ir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/object_singleton.fir.ir.txt
@@ -1,0 +1,203 @@
+FILE fqName:<root> fileName:/appModuleModule.kt
+  FUN GENERATED[org.koin.compiler.plugin.fir.KoinModuleFirGenerator.Key] name:module visibility:public modality:FINAL returnType:org.koin.core.module.Module
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.AppModule
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun module (<this>: <root>.AppModule): org.koin.core.module.Module declared in <root>'
+        CALL 'public final fun module (createdAtStart: kotlin.Boolean, moduleDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.module.Module, kotlin.Unit>): org.koin.core.module.Module declared in org.koin.dsl' type=org.koin.core.module.Module origin=null
+          ARG moduleDeclaration: FUN_EXPR type=kotlin.Function1<org.koin.core.module.Module, kotlin.Unit> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+              VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.module.Module
+              BLOCK_BODY
+                CALL 'public final fun bind <S> (<this>: org.koin.core.definition.KoinDefinition<*>, clazz: kotlin.reflect.KClass<S of org.koin.plugin.module.dsl.bind>): org.koin.core.definition.KoinDefinition<*> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<*> origin=null
+                  TYPE_ARG S: <root>.Loader
+                  ARG <this>: CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                    TYPE_ARG T: <root>.MyLoader
+                    ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                    ARG kclass: CLASS_REFERENCE 'CLASS OBJECT name:MyLoader modality:FINAL visibility:public superTypes:[<root>.Loader]' type=kotlin.reflect.KClass<<root>.MyLoader>
+                    ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                    ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.MyLoader> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.MyLoader
+                        VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                        VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                        BLOCK_BODY
+                          RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.MyLoader declared in <root>.module.<anonymous>'
+                            GET_OBJECT 'CLASS OBJECT name:MyLoader modality:FINAL visibility:public superTypes:[<root>.Loader]' type=<root>.MyLoader
+                  ARG clazz: CLASS_REFERENCE 'CLASS INTERFACE name:Loader modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Loader>
+                CALL 'public final fun buildSingle <T> (<this>: org.koin.core.module.Module, kclass: kotlin.reflect.KClass<T of org.koin.plugin.module.dsl.buildSingle>, qualifier: org.koin.core.qualifier.Qualifier?, definition: @[ExtensionFunctionType] kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, T of org.koin.plugin.module.dsl.buildSingle>, createdAtStart: kotlin.Boolean): org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> declared in org.koin.plugin.module.dsl' type=org.koin.core.definition.KoinDefinition<T of org.koin.plugin.module.dsl.buildSingle> origin=null
+                  TYPE_ARG T: <root>.MyService
+                  ARG <this>: GET_VAR '<this>: org.koin.core.module.Module declared in <root>.module.<anonymous>' type=org.koin.core.module.Module origin=null
+                  ARG kclass: CLASS_REFERENCE 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.MyService>
+                  ARG qualifier: CONST Null type=kotlin.Nothing? value=null
+                  ARG definition: FUN_EXPR type=kotlin.Function2<org.koin.core.scope.Scope, org.koin.core.parameter.ParametersHolder, <root>.MyService> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:<root>.MyService
+                      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:org.koin.core.scope.Scope
+                      VALUE_PARAMETER kind:Regular name:params index:1 type:org.koin.core.parameter.ParametersHolder
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (<this>: org.koin.core.scope.Scope, params: org.koin.core.parameter.ParametersHolder): <root>.MyService declared in <root>.module.<anonymous>'
+                          GET_OBJECT 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.MyService
+FILE fqName:org.koin.plugin.hints fileName:/koin_hints_AppModule_9b690110ed8c2a44.kt
+  FUN name:componentscan_appModule_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyLoader
+    VALUE_PARAMETER kind:Regular name:binding0 index:1 type:<root>.Loader
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+  FUN name:componentscan_appModule_single visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:contributed index:0 type:<root>.MyService
+    annotations:
+      Deprecated(message = "Koin compiler plugin internal hint function", replaceWith = <null>, level = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:HIDDEN' type=kotlin.DeprecationLevel)
+    BLOCK_BODY
+FILE fqName:<root> fileName:/test.kt
+  CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Module(includes = <null>, createdAtStart = <null>)
+      ComponentScan(value = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AppModule
+    CONSTRUCTOR visibility:public returnType:<root>.AppModule [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:AppModule modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS INTERFACE name:Loader modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Loader
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    PROPERTY name:name visibility:public modality:ABSTRACT [val]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:ABSTRACT returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Loader
+        correspondingProperty: PROPERTY name:name visibility:public modality:ABSTRACT [val]
+  CLASS OBJECT name:MyLoader modality:FINAL visibility:public superTypes:[<root>.Loader]
+    annotations:
+      Single(binds = [CLASS_REFERENCE 'CLASS INTERFACE name:Loader modality:ABSTRACT visibility:public superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Loader>] type=kotlin.Array<kotlin.reflect.KClass<*>> varargElementType=kotlin.reflect.KClass<*>, createdAtStart = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MyLoader
+    PROPERTY name:name visibility:public modality:OPEN [val]
+      overridden:
+        public abstract name: kotlin.String declared in <root>.Loader
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          CONST String type=kotlin.String value="my-loader"
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:OPEN returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.MyLoader
+        correspondingProperty: PROPERTY name:name visibility:public modality:OPEN [val]
+        overridden:
+          public abstract fun <get-name> (): kotlin.String declared in <root>.Loader
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun <get-name> (): kotlin.String declared in <root>.MyLoader'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.MyLoader declared in <root>.MyLoader.<get-name>' type=<root>.MyLoader origin=null
+    CONSTRUCTOR visibility:private returnType:<root>.MyLoader [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:MyLoader modality:FINAL visibility:public superTypes:[<root>.Loader]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Loader
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.Loader
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.Loader
+  CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Singleton(binds = <null>, createdAtStart = <null>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MyService
+    CONSTRUCTOR visibility:private returnType:<root>.MyService [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:koin type:org.koin.core.Koin [val]
+        CALL 'public final fun <get-koin> (): org.koin.core.Koin declared in org.koin.core.KoinApplication' type=org.koin.core.Koin origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun startKoin (appDeclaration: @[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit>): org.koin.core.KoinApplication declared in org.koin.core.context' type=org.koin.core.KoinApplication origin=null
+            ARG appDeclaration: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<org.koin.core.KoinApplication, kotlin.Unit> origin=LAMBDA
+              FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                VALUE_PARAMETER kind:ExtensionReceiver name:$this$startKoin index:0 type:org.koin.core.KoinApplication
+                BLOCK_BODY
+                  TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+                    CALL 'public final fun modules (modules: org.koin.core.module.Module): org.koin.core.KoinApplication declared in org.koin.core.KoinApplication' type=org.koin.core.KoinApplication origin=null
+                      ARG <this>: GET_VAR '$this$startKoin: org.koin.core.KoinApplication declared in <root>.box.<anonymous>' type=org.koin.core.KoinApplication origin=IMPLICIT_ARGUMENT
+                      ARG modules: CALL 'public final fun module (<this>: <root>.AppModule): org.koin.core.module.Module declared in <root>' type=org.koin.core.module.Module origin=null
+                        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.AppModule' type=<root>.AppModule origin=null
+      VAR name:loader type:<root>.Loader [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.Loader origin=null
+          TYPE_ARG T: <root>.Loader
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      VAR name:service type:<root>.MyService [val]
+        CALL 'public final fun get <T> (qualifier: org.koin.core.qualifier.Qualifier?, parameters: kotlin.Function0<org.koin.core.parameter.ParametersHolder>?): T of org.koin.core.Koin.get declared in org.koin.core.Koin' type=<root>.MyService origin=null
+          TYPE_ARG T: <root>.MyService
+          ARG <this>: GET_VAR 'val koin: org.koin.core.Koin declared in <root>.box' type=org.koin.core.Koin origin=null
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQEQ
+            ARG <this>: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQEQ
+              ARG arg0: GET_VAR 'val loader: <root>.Loader declared in <root>.box' type=<root>.Loader origin=null
+              ARG arg1: GET_OBJECT 'CLASS OBJECT name:MyLoader modality:FINAL visibility:public superTypes:[<root>.Loader]' type=<root>.MyLoader
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: Loader is not MyLoader INSTANCE"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQEQ
+            ARG <this>: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQEQ
+              ARG arg0: GET_VAR 'val service: <root>.MyService declared in <root>.box' type=<root>.MyService origin=null
+              ARG arg1: GET_OBJECT 'CLASS OBJECT name:MyService modality:FINAL visibility:public superTypes:[kotlin.Any]' type=<root>.MyService
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            CONST String type=kotlin.String value="FAIL: MyService is not INSTANCE"
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public open fun <get-name> (): kotlin.String declared in <root>.MyLoader' type=kotlin.String origin=GET_PROPERTY
+                ARG <this>: TYPE_OP type=<root>.MyLoader origin=IMPLICIT_CAST typeOperand=<root>.MyLoader
+                  GET_VAR 'val loader: <root>.Loader declared in <root>.box' type=<root>.Loader origin=null
+              ARG arg1: CONST String type=kotlin.String value="my-loader"
+          then: RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+            STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="FAIL: wrong name "
+              CALL 'public open fun <get-name> (): kotlin.String declared in <root>.MyLoader' type=kotlin.String origin=GET_PROPERTY
+                ARG <this>: TYPE_OP type=<root>.MyLoader origin=IMPLICIT_CAST typeOperand=<root>.MyLoader
+                  GET_VAR 'val loader: <root>.Loader declared in <root>.box' type=<root>.Loader origin=null
+      CALL 'public final fun stopKoin (): kotlin.Unit declared in org.koin.core.context' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/koin-compiler-plugin/testData/box/annotations/object_singleton.fir.txt
+++ b/koin-compiler-plugin/testData/box/annotations/object_singleton.fir.txt
@@ -1,0 +1,57 @@
+FILE: test.kt
+    public abstract interface Loader : R|kotlin/Any| {
+        public abstract val name: R|kotlin/String|
+            public get(): R|kotlin/String|
+
+    }
+    @R|org/koin/core/annotation/Single|(binds = <collectionLiteralCall>(<getClass>(Q|Loader|))) public final object MyLoader : R|Loader| {
+        private constructor(): R|MyLoader| {
+            super<R|kotlin/Any|>()
+        }
+
+        public open override val name: R|kotlin/String| = String(my-loader)
+            public get(): R|kotlin/String|
+
+    }
+    @R|org/koin/core/annotation/Singleton|() public final object MyService : R|kotlin/Any| {
+        private constructor(): R|MyService| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|org/koin/core/annotation/Module|() @R|org/koin/core/annotation/ComponentScan|() public final class AppModule : R|kotlin/Any| {
+        public constructor(): R|AppModule| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval koin: R|org/koin/core/Koin| = R|org/koin/core/context/startKoin|(<L> = startKoin@fun R|org/koin/core/KoinApplication|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+            this@R|special/anonymous|.R|org/koin/core/KoinApplication.modules|(R|/AppModule.AppModule|().R|/module|())
+        }
+        ).R|org/koin/core/KoinApplication.koin|
+        lval loader: R|Loader| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|Loader|>()
+        lval service: R|MyService| = R|<local>/koin|.R|org/koin/core/Koin.get|<R|MyService|>()
+        when () {
+            !==(R|<local>/loader|, Q|MyLoader|) ->  {
+                ^box String(FAIL: Loader is not MyLoader INSTANCE)
+            }
+        }
+
+        when () {
+            !==(R|<local>/service|, Q|MyService|) ->  {
+                ^box String(FAIL: MyService is not INSTANCE)
+            }
+        }
+
+        when () {
+            !=(R|<local>/loader|.R|/MyLoader.name|, String(my-loader)) ->  {
+                ^box <strcat>(String(FAIL: wrong name ), R|<local>/loader|.R|/MyLoader.name|)
+            }
+        }
+
+        R|org/koin/core/context/stopKoin|()
+        ^box String(OK)
+    }
+FILE: /appModuleModule.kt
+    public final fun R|AppModule|.module(): R|org/koin/core/module/Module|

--- a/koin-compiler-plugin/testData/box/annotations/object_singleton.kt
+++ b/koin-compiler-plugin/testData/box/annotations/object_singleton.kt
@@ -1,0 +1,42 @@
+// FILE: test.kt
+// Regression test for #77: @Single/@Singleton on a Kotlin object must reference INSTANCE,
+// not call the synthesized constructor (which has no public access and caused NoSuchMethodError).
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+import org.koin.core.annotation.Singleton
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+
+interface Loader {
+    val name: String
+}
+
+@Single([Loader::class])
+object MyLoader : Loader {
+    override val name: String = "my-loader"
+}
+
+@Singleton
+object MyService
+
+@Module
+@ComponentScan
+class AppModule
+
+fun box(): String {
+    val koin = startKoin {
+        modules(AppModule().module())
+    }.koin
+
+    val loader = koin.get<Loader>()
+    val service = koin.get<MyService>()
+
+    // Must be the actual INSTANCE, not a new instance constructed via <init>
+    if (loader !== MyLoader) return "FAIL: Loader is not MyLoader INSTANCE"
+    if (service !== MyService) return "FAIL: MyService is not INSTANCE"
+    if (loader.name != "my-loader") return "FAIL: wrong name ${loader.name}"
+
+    stopKoin()
+    return "OK"
+}


### PR DESCRIPTION
fixes #77

## Fix

In `DefinitionCallBuilder.buildClassDefinitionCall` and `buildScopedClassDefinitionCall`, detect `targetClass.isObject` before calling `findConstructorToUse`. For objects, skip the constructor path entirely and use a new `createObjectDefinitionLambda` that emits `irGetObject(targetClass.symbol)` — the same `GET_OBJECT` IR node the Kotlin compiler itself uses for every other object reference.

The lambda body goes from:
```
{ MyObject() }   // broken: calls inaccessible <init>
```
to:
```
{ MyObject }     // correct: reads INSTANCE
```

## Test

Added `object_singleton` box test: a `@Single` object with an interface binding and a plain `@Singleton` object, both resolved via `startKoin`. Asserts identity (`===`) against the actual `INSTANCE` to confirm no new instance is constructed.
